### PR TITLE
Added gulp plugin link

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,8 @@ li > ul {
 <li>
 <a href="https://github.com/jzaefferer/grunt-html">Grunt plugin for HTML validation</a>
 <li>
+<a href="https://github.com/watilde/gulp-html">gulp plugin for HTML validation</a>
+<li>
 <a href="https://github.com/svenkreiss/html5validator">HTML5 Validator Integration for Travis CI</a>
 (auto-check documents pushed to a github repo)
 <li>


### PR DESCRIPTION
Hi

I love to use this validator. So I created a gulp plugin using vnu.jar, could I add a link on this page? I'd be happy to do that.

You can see the preview at this url: http://watilde.github.io/validator/index.html

Thanks.