### PR TITLE
datatype.Pattern: for consistency, explicitly disable JS optimization

### DIFF
--- a/src/nu/validator/datatype/Pattern.java
+++ b/src/nu/validator/datatype/Pattern.java
@@ -60,6 +60,7 @@ public final class Pattern extends AbstractDatatype {
         // TODO find out what kind of thread concurrency guarantees are made
         ContextFactory cf = new ContextFactory();
         Context cx = cf.enterContext();
+        cx.setOptimizationLevel(0);
         RegExpImpl rei = new RegExpImpl();
         String anchoredRegex = "^(?:" + literal + ")$";
         try {


### PR DESCRIPTION
As elsewhere, the JS code here is trivial and completely transient, so there's no point in wasting time trying to optimize it. And this seemed to be the only Context creation anywhere that didn't already call `.setOptimizationLevel()`.