### PR TITLE
Enable Rhino optimizations for parse-css

### DIFF
--- a/src/nu/validator/datatype/tools/CssParser.java
+++ b/src/nu/validator/datatype/tools/CssParser.java
@@ -49,7 +49,7 @@ public class CssParser {
                                     "nu/validator/localentities/files/parse-css-js")));
             br.mark(1);
             Context context = ContextFactory.getGlobal().enterContext();
-            context.setOptimizationLevel(0);
+            context.setOptimizationLevel(1);
             context.setLanguageVersion(Context.VERSION_1_6);
             scope = context.initStandardObjects();
             context.evaluateReader(scope, br, null, -1, null);


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino/Optimization and some inspection of Rhino's code, the available optimization levels seem to be:
* `-1` = Required if using continuations (not applicable). Enable TCE (not applicable). Emit no bytecode so that the "compilation" process itself is fast; uses a "slow" interpreter.
* `0` = Emit unoptimized bytecode
* `1` thru `9` inclusive = Emit optimized bytecode. All these levels are identical.

This PR therefore enables optimization level `1`. The longer compilation time should be more than offset by invocations of this JS being faster over the rest of the life of the server process.
Fixes #62.