### PR TITLE
For file uploads, use supplied filename as sysID.

### DIFF
--- a/src/nu/validator/servlet/VerifierServletTransaction.java
+++ b/src/nu/validator/servlet/VerifierServletTransaction.java
@@ -668,6 +668,10 @@ class VerifierServletTransaction implements DocumentModeHandler, SchemaResolver 
         if (document == null) {
             document = request.getParameter("doc");
         }
+        if ("".equals(document)
+                && request.getAttribute("nu.validator.servlet.MultipartFormDataFilter.filename") != null) {
+            document = (String) request.getAttribute("nu.validator.servlet.MultipartFormDataFilter.filename");
+        }
 
         document = ("".equals(document)) ? null : document;
 
@@ -895,6 +899,10 @@ class VerifierServletTransaction implements DocumentModeHandler, SchemaResolver 
         entityResolver = new LocalCacheEntityResolver(dataRes);
         setAllowRnc(true);
         try {
+            if (document == null
+                    && request.getAttribute("nu.validator.servlet.MultipartFormDataFilter.filename") != null) {
+                document = (String) request.getAttribute("nu.validator.servlet.MultipartFormDataFilter.filename");
+            }
             this.errorHandler.start(document);
             PropertyMapBuilder pmb = new PropertyMapBuilder();
             pmb.put(ValidateProperty.ERROR_HANDLER, errorHandler);
@@ -1928,6 +1936,10 @@ class VerifierServletTransaction implements DocumentModeHandler, SchemaResolver 
                     request.getInputStream(), SIZE_LIMIT, document)
                     : request.getInputStream());
             documentInput.setSystemId(request.getHeader("Content-Location"));
+            if (documentInput.getSystemId() == null
+                    && request.getAttribute("nu.validator.servlet.MultipartFormDataFilter.filename") != null) {
+                documentInput.setSystemId((String) request.getAttribute("nu.validator.servlet.MultipartFormDataFilter.filename"));
+            }
         }
         if (imageCollector != null) {
             baseUriTracker = new BaseUriTracker(documentInput.getSystemId(),


### PR DESCRIPTION
Form-based file uploads sent as `multipart/form-data` typically include a
field that gives the original filename of the uploaded file. This change
causes the filename to be included in every error or warning message the
checker emits when checking the uploaded file.

Note that there's an important limitation to understand for this case: The
filename information made available to the backend for file uploads is
simply just a filename -- not an absolute pathname and not even a relative
pathname. That means, e.g., if you're recursing through a directory tree,
the messages emitted for a file named `index.html` at the top level and the
messages emitted for file named `index.html` in some subdirectory are both
going to report the filename as just `index.html` even though they're
actually different files.