### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Please refer .settings directory for java coding styles
+[*.java]
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_style = space
+indent_size = 2
+
+[*.{js,css,xml}]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
The coding styles of Nu Html Checker are vary with file types. While the Eclipse settings are provided for java source files, there is no explicit coding styles information for other files.

This commit adds basic coding styles for *.java, *.py, *.js, *.css, *.xml.

Please refer  [EditorConfig website](http://editorconfig.org/) for syntax of .editorconfig.