### PR TITLE
inputmode attribute support for input and textarea tags

### DIFF
--- a/schema/html5/web-forms.rnc
+++ b/schema/html5/web-forms.rnc
@@ -35,6 +35,23 @@ datatypes w = "http://whattf.org/datatype-draft"
 		attribute size {
 			common.data.integer.positive
 		}
+
+	shared-form.attrs.inputmode =
+		attribute inputmode {
+			w:string "verbatim" |
+			w:string "latin" |
+			w:string "latin-name" |
+			w:string "latin-prose" |
+			w:string "full-width-latin" |
+			w:string "kana" |
+			w:string "kana-name" |
+			w:string "katakana" |
+			w:string "numeric" |
+			w:string "tel" |
+			w:string "email" |
+			w:string "url"
+		}
+
 	
 	# REVISIT tabindex goes in common.attrs
 
@@ -52,6 +69,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 	input.text.attrs = 
 		(	common.attrs
 		&	common-form.attrs
+		&	shared-form.attrs.inputmode?
 		&	input.text.attrs.type?
 		&	shared-form.attrs.maxlength? 
 		&	shared-form.attrs.readonly?
@@ -319,6 +337,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 	textarea.attrs =
 		(	common.attrs
 		&	common-form.attrs
+		&	shared-form.attrs.inputmode?
 		&	shared-form.attrs.readonly?
 		&	textarea.attrs.rows-and-cols-wf1
 		&	(	common.attrs.aria.implicit.textbox
@@ -601,4 +620,3 @@ datatypes w = "http://whattf.org/datatype-draft"
 		( common.inner.phrasing ) #REVISIT making obvious guess
 
 	common.elem.phrasing |= label.elem
-


### PR DESCRIPTION
inputmode attribute is present in [HTML5 spec](http://www.w3.org/TR/html5/forms.html#the-input-element) without any details, [HTML5.1 editor draft](http://www.w3.org/html/wg/drafts/html/master/semantics.html#input-modalities:-the-inputmode-attribute) is giving better specification as well as [WHATWG living standard](https://html.spec.whatwg.org/multipage/forms.html#attr-fe-inputmode). Currently inputmode attribute is not validated properly by validator.
I don't know what policy is for those not-really-released features, but this PR can be useful when inputmode finally makes its way into spec.