### PR TITLE
Fix "Ignore input[type=hidden] label descendants."

### DIFF
--- a/src/nu/validator/checker/schematronequiv/Assertions.java
+++ b/src/nu/validator/checker/schematronequiv/Assertions.java
@@ -1990,7 +1990,7 @@ public class Assertions extends Checker {
 
             // labelable elements
             if ("button" == localName
-                    || ("input" == localName && atts.getIndex("", "hidden") < 0)
+                    || ("input" == localName && !lowerCaseLiteralEqualsIgnoreAsciiCaseString("hidden", atts.getValue("", "type")))
                     || "keygen" == localName || "meter" == localName
                     || "output" == localName || "progress" == localName
                     || "select" == localName || "textarea" == localName) {


### PR DESCRIPTION
https://github.com/validator/validator/commit/d1d38e5905c1701d33ae7133a12b339e3aeced98
makes validator ignore input[hidden]. This commit makes validator not ignore input[hidden] but input[type=hidden].

Signed-off-by: Takeshi Kurosawa <taken.spc@gmail.com>