### PR TITLE
Use portable directives in `time.strftime`

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -62,7 +62,7 @@ nightliesPath = "/var/www/nightlies"
 releasesPath = "/var/www/releases"
 
 releaseDate = time.strftime('%d %B %Y')
-validatorVersion = time.strftime('%y.%-m.%-e')
+validatorVersion = time.strftime('%y.%m.%d')
 jingVersion = "20150629VNU"
 htmlparserVersion = "1.4.1"
 


### PR DESCRIPTION
This commit changes `validatorVersion` to "15.08.01" from "15.8.1"

References:

- https://docs.python.org/2/library/time.html#time.strftime
- http://strftime.org/

Signed-off-by: Takeshi Kurosawa <taken.spc@gmail.com>