### PR TITLE
build.py: Avoid unnecessary Windows special-casing when writing to files

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -262,10 +262,7 @@ def runJavac(sourceDir, classDir, classPath):
   ensureDirExists(classDir)
   sourceFiles = findFilesWithExtension(sourceDir, "java")
   f = open("temp-javac-list", "w")
-  if os.name == 'nt':
-    f.write("\r\n".join(sourceFiles))
-  else:
-    f.write("\n".join(sourceFiles))
+  f.write("\n".join(sourceFiles))
   f.close()
   args = [
     '-g',
@@ -307,10 +304,7 @@ def runJar(classDir, jarFile, sourceDir):
                for x in
                classFiles]
   f = open("temp-jar-list", "w")
-  if os.name == 'nt':
-    f.write("\r\n".join(classList))
-  else:
-    f.write("\n".join(classList))
+  f.write("\n".join(classList))
   f.close()
   runCmd('"%s" cf "%s" %s'
     % (jarCmd, jarFile, "@temp-jar-list"))


### PR DESCRIPTION
For files opened in text mode (which is the default) (as opposed to binary mode, the `'b'` mode flag), calling `file.write("\n")` causes the platform-appropriate newline byte sequence to be written to the file (CRLF on Windows, LF elsewhere).
See http://stackoverflow.com/questions/21636213/why-you-shouldnt-use-os-linesep-when-editing-on-text-mode