### PR TITLE
Fix regular expression of the hash-expression/hash-source.

### DIFF
--- a/src/nu/validator/datatype/IntegrityMetadata.java
+++ b/src/nu/validator/datatype/IntegrityMetadata.java
@@ -37,7 +37,7 @@ public final class IntegrityMetadata extends AbstractDatatype {
     public static final IntegrityMetadata THE_INSTANCE = new IntegrityMetadata();
 
     private static final Pattern THE_PATTERN = Pattern.compile(
-            "^(?:sha256-|sha384-|sha512)(.+$)", Pattern.CASE_INSENSITIVE);
+            "^(?:sha256|sha384|sha512)-(.+$)", Pattern.CASE_INSENSITIVE);
 
     private IntegrityMetadata() {
         super();


### PR DESCRIPTION
Current regular expression warns for `integrity="sha512-(base64)"`.

```html
<script src="alert.js" integrity="sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzCinRE7Af1ofPrw=="></script>
```

However it doesn't warn for `integrity="sha512(base64)"`.

```html
<script src="alert.js" integrity="sha512Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzCinRE7Af1ofPrw=="></script>
```