### PR TITLE
Update fragment of input elements

### DIFF
--- a/src/nu/validator/messages/MessageEmitterAdapter.java
+++ b/src/nu/validator/messages/MessageEmitterAdapter.java
@@ -257,33 +257,33 @@ public final class MessageEmitterAdapter implements ErrorHandler {
     private static final Map<String, String> fragmentIdByInputType = new TreeMap<>();
 
     static {
-        fragmentIdByInputType.put("hidden", "#hidden-state-type-hidden");
+        fragmentIdByInputType.put("hidden", "#hidden-state-(type=hidden)");
         fragmentIdByInputType.put("text",
-                "#text-type-text-state-and-search-state-type-search");
+                "#text-(type=text)-state-and-search-state-(type=search)");
         fragmentIdByInputType.put("search",
-                "#text-type-text-state-and-search-state-type-search");
-        fragmentIdByInputType.put("url", "#url-state-type-url");
-        fragmentIdByInputType.put("tel", "#telephone-state-type-tel");
-        fragmentIdByInputType.put("email", "#e-mail-state-type-email");
-        fragmentIdByInputType.put("password", "#password-state-type-password");
+                "#text-(type=text)-state-and-search-state-(type=search)");
+        fragmentIdByInputType.put("tel", "#telephone-state-(type=tel)");
+        fragmentIdByInputType.put("url", "#url-state-(type=url)");
+        fragmentIdByInputType.put("email", "#e-mail-state-(type=email)");
+        fragmentIdByInputType.put("password", "#password-state-(type=password)");
         fragmentIdByInputType.put("datetime",
-                "#date-and-time-state-type-datetime");
-        fragmentIdByInputType.put("date", "#date-state-type-date");
-        fragmentIdByInputType.put("month", "#month-state-type-month");
-        fragmentIdByInputType.put("week", "#week-state-type-week");
-        fragmentIdByInputType.put("time", "#time-state-type-time");
+                "#date-and-time-state-(type=datetime)");
+        fragmentIdByInputType.put("date", "#date-state-(type=date)");
+        fragmentIdByInputType.put("month", "#month-state-(type=month)");
+        fragmentIdByInputType.put("week", "#week-state-(type=week)");
+        fragmentIdByInputType.put("time", "#time-state-(type=time)");
         fragmentIdByInputType.put("datetime-local",
-                "#local-date-and-time-state-type-datetime-local");
-        fragmentIdByInputType.put("number", "#number-state-type-number");
-        fragmentIdByInputType.put("range", "#range-state-type-range");
-        fragmentIdByInputType.put("color", "#color-state-type-color");
-        fragmentIdByInputType.put("checkbox", "#checkbox-state-type-checkbox");
-        fragmentIdByInputType.put("radio", "#radio-button-state-type-radio");
-        fragmentIdByInputType.put("file", "#file-upload-state-type-file");
-        fragmentIdByInputType.put("submit", "#submit-button-state-type-submit");
-        fragmentIdByInputType.put("image", "#image-button-state-type-image");
-        fragmentIdByInputType.put("reset", "#reset-button-state-type-reset");
-        fragmentIdByInputType.put("button", "#button-state-type-button");
+                "#local-date-and-time-state-(type=datetime-local)");
+        fragmentIdByInputType.put("number", "#number-state-(type=number)");
+        fragmentIdByInputType.put("range", "#range-state-(type=range)");
+        fragmentIdByInputType.put("color", "#color-state-(type=color)");
+        fragmentIdByInputType.put("checkbox", "#checkbox-state-(type=checkbox)");
+        fragmentIdByInputType.put("radio", "#radio-button-state-(type=radio)");
+        fragmentIdByInputType.put("file", "#file-upload-state-(type=file)");
+        fragmentIdByInputType.put("submit", "#submit-button-state-(type=submit)");
+        fragmentIdByInputType.put("image", "#image-button-state-(type=image)");
+        fragmentIdByInputType.put("reset", "#reset-button-state-(type=reset)");
+        fragmentIdByInputType.put("button", "#button-state-(type=button)");
     }
 
     static {

--- a/src/nu/validator/messages/MessageEmitterAdapter.java
+++ b/src/nu/validator/messages/MessageEmitterAdapter.java
@@ -182,7 +182,7 @@ public final class MessageEmitterAdapter implements ErrorHandler {
                 "#attr-input-alt", "image" });
         validInputTypesByAttributeName.put("autocomplete", new String[] {
                 "#attr-input-autocomplete", "text", "search", "url", "tel",
-                "e-mail", "password", "datetime", "date", "month", "week",
+                "email", "password", "datetime", "date", "month", "week",
                 "time", "datetime-local", "number", "range", "color" });
         validInputTypesByAttributeName.put("autofocus",
                 new String[] { "#attr-fe-autofocus" });
@@ -207,7 +207,7 @@ public final class MessageEmitterAdapter implements ErrorHandler {
         validInputTypesByAttributeName.put("height", new String[] {
                 "#attr-dim-height", "image" });
         validInputTypesByAttributeName.put("list", new String[] {
-                "#attr-input-list", "text", "search", "url", "tel", "e-mail",
+                "#attr-input-list", "text", "search", "url", "tel", "email",
                 "datetime", "date", "month", "week", "time", "datetime-local",
                 "number", "range", "color" });
         validInputTypesByAttributeName.put("max", new String[] {
@@ -215,7 +215,7 @@ public final class MessageEmitterAdapter implements ErrorHandler {
                 "datetime-local", "number", "range", });
         validInputTypesByAttributeName.put("maxlength", new String[] {
                 "#attr-input-maxlength", "text", "search", "url", "tel",
-                "e-mail", "password" });
+                "email", "password" });
         validInputTypesByAttributeName.put("min", new String[] {
                 "#attr-input-min", "datetime", "date", "month", "week", "time",
                 "datetime-local", "number", "range", });
@@ -225,21 +225,21 @@ public final class MessageEmitterAdapter implements ErrorHandler {
                 new String[] { "#attr-fe-name" });
         validInputTypesByAttributeName.put("pattern", new String[] {
                 "#attr-input-pattern", "text", "search", "url", "tel",
-                "e-mail", "password" });
+                "email", "password" });
         validInputTypesByAttributeName.put("placeholder", new String[] {
                 "#attr-input-placeholder", "text", "search", "url", "tel",
-                "e-mail", "password", "number" });
+                "email", "password", "number" });
         validInputTypesByAttributeName.put("readonly", new String[] {
                 "#attr-input-readonly", "text", "search", "url", "tel",
-                "e-mail", "password", "datetime", "date", "month", "week",
+                "email", "password", "datetime", "date", "month", "week",
                 "time", "datetime-local", "number" });
         validInputTypesByAttributeName.put("required",
                 new String[] { "#attr-input-required", "text", "search", "url",
-                        "tel", "e-mail", "password", "datetime", "date",
+                        "tel", "email", "password", "datetime", "date",
                         "month", "week", "time", "datetime-local", "number",
                         "checkbox", "radio", "file" });
         validInputTypesByAttributeName.put("size", new String[] {
-                "#attr-input-size", "text", "search", "url", "tel", "e-mail",
+                "#attr-input-size", "text", "search", "url", "tel", "email",
                 "password" });
         validInputTypesByAttributeName.put("src", new String[] {
                 "#attr-input-src", "image" });


### PR DESCRIPTION
- Replace e-mail with email because it is typo
- Update fragment except datetime per HTML Standard
- Update datetime fragment per [HTML 5.1 (20151008)](https://www.w3.org/TR/2015/WD-html51-20151008/semantics.html#date-and-time-state-%28type=datetime%29)
- Reroder tel and url to match HTML Standard