### PR TITLE
Fix #285: Remove <label form> to match current spec

### DIFF
--- a/schema/html5/web-forms2.rnc
+++ b/schema/html5/web-forms2.rnc
@@ -749,11 +749,6 @@ datatypes w = "http://whattf.org/datatype-draft"
 	fieldset.attrs &=
 		( common-form.attrs )
 
-## Label: <label>, extensions
-
-	label.attrs &=
-		( common-form.attrs.form? )
-
 ## Key-pair generator/input control: <keygen>
 
 	keygen.elem =


### PR DESCRIPTION
Not tested.

@sideshowbarker r?