### PR TITLE
Fix NPE in TestRunner

### DIFF
--- a/src/nu/validator/client/TestRunner.java
+++ b/src/nu/validator/client/TestRunner.java
@@ -457,7 +457,7 @@ public class TestRunner implements ErrorHandler {
 
     public boolean runTestSuite() throws SAXException, Exception {
         if (messagesFile != null) {
-            baseDir = messagesFile.getParentFile();
+            baseDir = messagesFile.getCanonicalFile().getParentFile();
             FileInputStream fis = new FileInputStream(messagesFile);
             InputStreamReader reader = new InputStreamReader(fis, "UTF-8");
             expectedMessages = (HashMap<String, String>) JSON.parse(reader);


### PR DESCRIPTION
Removal of `getAbsoluteFile()` in #341 was wrong. As the File class represents abstracted pathname, current TestRunner can't find baseDir if message.json argument has no parent part.

We need to convert relative path to absolute path to ensure that TestRunner is able to find the baseDir. According to https://blogs.oracle.com/foo/entry/tip_13_java_io_file, we should use getCanonicalFile() for this purpose.