### PR TITLE
fix #354 urlopen() cafile

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -1106,7 +1106,7 @@ def fetchUrlTo(url, path, md5sum=None):
   while not completed:
    try:
     socket.setdefaulttimeout(httpTimeoutSeconds)
-    f = urlopen(url, cafile=CAFILE)
+    f = urlopen(url)
     data = f.read()
     f.close()
     completed = True


### PR DESCRIPTION
#354 build.py:1109 "urlopen() got an unexpected keyword argument 'cafile'"