### PR TITLE
Create package `vnu-jar` in NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+# All
+*
+
+# But not
+!/build/dist/vnu.jar
+!vnu-jar.js

--- a/README.md
+++ b/README.md
@@ -51,6 +51,47 @@ automating your HTML checking with a frontend such as:
    [16]: https://github.com/svenkreiss/html5validator
    [17]: https://github.com/cvrebert/lmvtfy/
 
+
+## vnu.jar in NPM
+You can work with `vnu.jar` in CommonJS modules.
+
+### Install latest release version
+```sh
+$ npm install --save vnu-jar
+```
+
+### Install latest dev version
+```sh
+$ npm install --save vnu-jar@dev
+```
+
+### Example
+For Node.js 6+
+```javascript
+'use strict';
+
+const exec = require ( 'child_process' ).exec;
+const vnu = require ( 'vnu-jar' );
+
+// Print path to vnu.jar
+console.log ( vnu );
+
+// Work with vnu.jar
+// for example get vnu.jar version
+exec ( `java -jar ${vnu} --version`, ( error, stdout ) => {
+
+	if ( error ) {
+		console.error ( `exec error: ${error}` );
+		return;
+	}
+
+	console.log ( stdout );
+
+} );
+
+```
+
+
 ## Usage
 
 You can use the `vnu.jar` HTML checker as an executable for command-line

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "validator",
+  "name": "vnu-jar",
   "version": "16.6.29",
-  "description": "The Nu Html Checker",
+  "description": "Provides the Nu Html Checker «vnu.jar» file",
+  "main": "vnu-jar.js",
+  "engines": {
+    "node": ">=0.10"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/validator/validator.git"

--- a/package.json
+++ b/package.json
@@ -14,5 +14,14 @@
   "bugs": {
     "url": "https://github.com/validator/validator/issues"
   },
-  "homepage": "https://github.com/validator/validator#readme"
+  "homepage": "https://github.com/validator/validator#readme",
+  "keywords": [
+    "checker",
+    "html",
+    "jar",
+    "nu",
+    "validator",
+    "vnu",
+    "w3c"
+  ]
 }

--- a/vnu-jar.js
+++ b/vnu-jar.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = __dirname + '/build/dist/vnu.jar';


### PR DESCRIPTION
Fix #409

It's a start. Since You want to publish to NPM, I'll tell You how to act, after merging this PR. Strongly reccomended using NPM 3+ (included in Node.js 6+) for publish.

Steps for **first publish** of current release in NPM:
1. Create a profile in [NPM](https://www.npmjs.com/signup) and populate your profile.
2. Open terminal and change your working directory to `validator`.
3. Since last release is `16.6.29`, so you need get `vnu.jar` with this version. For example, get `vnu.jar` from https://github.com/validator/validator/releases/download/16.6.29/vnu.jar_16.6.29.zip and put it in `/build/dist/` folder.
4. To be sure You can verify the version `vnu.jar` by executing 
    ```sh
    $ java -jar ./build/dist/vnu.jar --version
    ```
    Should output `16.6.29`.
5. To be sure You can verify current version `vnu-jar`. Look in `package.json` file. Version must be `16.6.29`. Once a package is published with a given name and version, that specific name and version combination can never be used again.
6. Before publishing: make sure your `vnu.jar` file inside package. We will [pack]() it for test.
    ```sh
    # Create a tarball from a package
    $ npm pack
    
    # Then unpack
    $ tar -xzvf vnu-jar-16.6.29.tgz

    # See what inside
    $ tree -a package/
    package/
    ├── build
    │   └── dist
    │       └── vnu.jar
    ├── CHANGELOG.md
    ├── LICENSE
    ├── package.json
    ├── README.md
    └── vnu-jar.js

    2 directories, 6 files

    # Ok! vnu.jar inside.
    # Clean up
    $ rm -rf vnu-jar-16.6.29.tgz package/
    ```
7. You made sure that the package is in order. Now You can log in NPM and publish:
    ```sh
    # Log in NPM. You usually need to do this once
    $ npm login

    # Then publish package. After executing this command, there is no way back!
    $ npm publish
    ```

---

For subsequent publication:
1. Build `vnu.jar` as you need. Test it as you want. `vnu.jar` must always be in `/build/dist/` folder. If it is ready, go ahead.
2. Change version in `package.json`. No matter what You build, stable or dev `vnu.jar`. The `vnu.jar` version should match the version in the `package.json` for publish. Always watch for this!
3. You can check what will be sent to NPM. Just run `npm pack` and see what inside. Don't forget that the `vnu.jar` must be inside.
4.   Now publish:
    - If it is `stable` release, run `npm publish`.
    - If it is `dev`, run `npm publish --tag dev`

More info about [tag](https://docs.npmjs.com/cli/dist-tag), [publish](https://docs.npmjs.com/cli/publish).

---

From myself I want to note that I would like to see in the `dev` version, which you pushing in `validator.w3.org/nu` each time (for now it is `16.11.16`). This will solve many problems, simplify the work. To get the fresh version.

If you want you can publish yours https://sideshowbarker.net/nightlies/jar/vnu.jar with tag `nightlies`. Do not forget to specify the version, for example `16.11.16-nightlies.1`, guided [Semantic Versioning](http://semver.org/spec/v2.0.0.html). I don't quite understand the difference betwen `nightlies` and versions pushing in `validator.w3.org/nu`. In the idea of nightly builds come out often.

If you have any questions and suggestions I will be glad to help. Write here or in [gitter](https://gitter.im/Arttse).