### PR TITLE
build/build.py: Remove checkjar output

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -1485,7 +1485,6 @@ def printHelp():
     print("  bundle   -- Create a Maven release bundle")
     print("  jar      -- Create a JAR file containing a release distribution")
     print("  war      -- Create a WAR file containing a release distribution")
-    print("  checkjar -- Run tests with the build jar file")
     print("  script   -- Make run-validator.sh script for running the system")
 
 


### PR DESCRIPTION
checkjar does not have any effect, so remove the misleading output.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>