### PR TITLE
Allow the "allow" attribute for iframe element

### DIFF
--- a/schema/html5/embed.rnc
+++ b/schema/html5/embed.rnc
@@ -446,6 +446,7 @@ namespace local = ""
 		&	iframe.attrs.allowfullscreen?
 		&	iframe.attrs.allowpaymentrequest?
 		&	iframe.attrs.allowusermedia?
+		&	iframe.attrs.allow?
 		&	referrerpolicy?
 		&	(	common.attrs.aria.role.application
 			|	common.attrs.aria.landmark.document
@@ -489,6 +490,10 @@ namespace local = ""
 			attribute allowusermedia {
 				w:string "allowusermedia" | w:string ""
 			} & v5only
+		iframe.attrs.allow =
+			attribute allow {
+				string #FIXME
+			}
 	iframe.inner =
 		empty
 


### PR DESCRIPTION
The `allow` attribute is [yet to be referenced](https://github.com/w3c/html/issues/1502) in the W3C HTML spec. The attribute is used to define a policy of allowed web APIs within an iframe.

The [feature policy spec](https://wicg.github.io/feature-policy/) will not list all potential [policies](https://github.com/WICG/feature-policy/blob/master/features.md) so it'll be a bit tedious to track, however the attribute itself should not give off errors in the validator.

The `allow` attribute has already been implemented in some UAs, https://caniuse.com/#search=feature-policy.

I welcome edits to this PR.
