### PR TITLE
Tweak CI configs more.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,33 +3,35 @@ version: "{build}"
 clone_depth: 5
 
 environment:
+  PYTHON: C:\Python34-x64
+  BUILD_PY: .\build\build.py
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - JAVA_HOME: C:\Program Files\Java\jdk9
     - JAVA_HOME: C:\Program Files\Java\jdk10
 
 install:
-  - set PATH=C:\Python35-x64;C:\Python35-x64\Scripts;%JAVA_HOME%\bin;%PATH%
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;%JAVA_HOME%\bin;%PATH%
   - java -version
   - python --version
   # Nu Html Checker uses utf-8 for output so change code page here
   - chcp 65001
   - pip install certifi
-  - python .\build\build.py update
+  - python %BUILD_PY% update
+  - python %BUILD_PY% dldeps
 
 build_script:
-  - python .\build\build.py dldeps
-  - python .\build\build.py build
+  - python %BUILD_PY% build
 
 test_script:
-  - python .\build\build.py check
-  - python .\build\build.py test
-  - echo "test" | python .\build\build.py jar
+  - python %BUILD_PY% check
+  - python %BUILD_PY% test
+  - python %BUILD_PY% jar
   - java -jar .\build\dist\vnu.jar .\build\dist\index.html
   - java -jar .\build\dist\vnu.jar .\site\nu-about.html
-  - echo "test" | python .\build\build.py war
+  - python %BUILD_PY% war
 
 cache:
   # cache the dependencies folder, and invalidate the cache
   # if any of the files right of the arrow change
-  - 'dependencies -> .appveyor.yml,build\build.py,build\build.xml'
+  - 'dependencies -> .appveyor.yml,%BUILD_PY%,build\build.xml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: java
 git:
   depth: 5
+  submodules: false # we do this ourselves later with `build.py update`
 
 matrix:
   include:
@@ -15,18 +16,22 @@ matrix:
     - jdk: oraclejdk10
       env: PYTHON=python3
 
-script:
+install:
   - export TOMCAT_VERSION=8.5.29
+  - export BUILD_PY=./build/build.py
+  - $PYTHON $BUILD_PY update
+  - travis_retry $PYTHON $BUILD_PY dldeps
+
+script:
   - $PYTHON --version
-  - travis_retry $PYTHON ./build/build.py dldeps
-  - travis_retry $PYTHON ./build/build.py build
-  - $PYTHON ./build/build.py check
-  - $PYTHON ./build/build.py test
-  - echo "test" | $PYTHON ./build/build.py jar
+  - travis_retry $PYTHON $BUILD_PY build
+  - $PYTHON $BUILD_PY check
+  - $PYTHON $BUILD_PY test
+  - $PYTHON $BUILD_PY jar
   - java -jar ./build/dist/vnu.jar ./build/dist/index.html
   - java -jar ./build/dist/vnu.jar ./site/nu-about.html
   - jar xf ./build/dist/vnu.jar && file nu/validator/client/SimpleCommandLineValidator.class | grep "version 52.0"
-  - echo "test" | $PYTHON ./build/build.py war
+  - $PYTHON $BUILD_PY war
   - jar xf ./build/dist/vnu.war && file WEB-INF/classes/nu/validator/servlet/VerifierServlet.class | grep "version 52.0"
   - curl -O http://archive.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.zip
   - unzip apache-tomcat-$TOMCAT_VERSION.zip


### PR DESCRIPTION
* AppVeyor: use Python 3.4 to match Travis
* remove `echo "test"` for jar/war commands
* move a few things to vars
* Travis: separate install step and disable submodules since we handle this ourselves
