### PR TITLE
Allow ARIA role=figure on figure element

### DIFF
--- a/schema/html5/media.rnc
+++ b/schema/html5/media.rnc
@@ -188,6 +188,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 	figure.attrs =
 		(	common.attrs
 		&	(	common.attrs.aria.implicit.figure
+			|	common.attrs.aria.role.figure
 			|	common.attrs.aria.role.presentation
 			|	common.attrs.aria.role.group
 			)?


### PR DESCRIPTION
`role=figure` is allowed on `figure` elements (even if a SHOULD NOT) in [ARIA in HTML](https://w3c.github.io/html-aria/#figure).

Currently, the following snippet:

```html
<figure role=figure>figure</figure>
```

is reported both as an error and a warning. This change should make the error go away.