### PR TITLE
Allow doc-glossary on section elements

### DIFF
--- a/schema/html5/structural.rnc
+++ b/schema/html5/structural.rnc
@@ -42,6 +42,7 @@
 			|	common.attrs.aria.role.doc-errata
 			|	common.attrs.aria.role.doc-example
 			|	common.attrs.aria.role.doc-foreword
+			|	common.attrs.aria.role.doc-glossary
 			|	common.attrs.aria.role.doc-index
 			|	common.attrs.aria.role.doc-introduction
 			|	common.attrs.aria.role.doc-notice


### PR DESCRIPTION
The `doc-glossary` role currently isn't allowed anywhere, but this PR changes that to allow it on `section` elements, as it is defined as a landmark role in DPUB-ARIA 1.0 and the accessibility mappings document.

The definition in DPUB-ARIA 1.0 unfortunately shows an incorrect example with the role on a `dl` element, but this will be updated in the next release of that specification. An issue to [fix the usage](https://github.com/w3c/html-aria/issues/128) has also been filed with ARIA in HTML document which picked up the example use.