### PR TITLE
Test on JDK 12 and remove 10 from AppVeyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,8 +7,8 @@ environment:
   BUILD_PY: .\build\build.py
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-    - JAVA_HOME: C:\Program Files\Java\jdk10
     - JAVA_HOME: C:\Program Files\Java\jdk11
+    - JAVA_HOME: C:\Program Files\Java\jdk12
 
 install:
   - set PATH=%PYTHON%;%PYTHON%\Scripts;%JAVA_HOME%\bin;%PATH%

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       env: PYTHON=python3
     - jdk: openjdk11
       env: PYTHON=python3
+    - jdk: openjdk12
+      env: PYTHON=python3
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_96f60dea8e9e_key -iv $encrypted_96f60dea8e9e_iv


### PR DESCRIPTION
@sideshowbarker: not sure what's the policy for the supported Java versions, I feel by keep adding more JDK versions will slow CI a lot, but personally I think it'd be good to test the latest version too.

Let me know how you want to proceed.