### PR TITLE
chore: Update AppVeyor Python to 3.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ version: "{build}"
 clone_depth: 5
 
 environment:
-  PYTHON: C:\Python34-x64
+  PYTHON: C:\Python36-x64
   BUILD_PY: .\build\build.py
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0


### PR DESCRIPTION

3.4 hit EOL on 2019-03-19
https://devguide.python.org/#status-of-python-branches