### PR TITLE
AppVeyor: remove `JAVA_HOME\bin` from `PATH`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk12
 
 install:
-  - set PATH=%PYTHON%;%PYTHON%\Scripts;%JAVA_HOME%\bin;%PATH%
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
   - java -version
   - python --version
   - python %BUILD_PY% update-shallow


### PR DESCRIPTION
It's not needed after 9fa8c3c

BTW @sideshowbarker perhaps we should use `os.path.join` in this?

https://github.com/validator/validator/blob/5695696bfacaf83c39105ae46f2b23d39cf33f94/build/build.py#L62-L67