### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8u111-jre-alpine
+FROM openjdk:13-alpine
 # to use:
 # docker build -t validator/validator .
 # docker run -it --rm \


### PR DESCRIPTION
This PR bumps the base docker image so that it can run the nightly build of `vnu.jar` again.

Fixes #792.