### PR TITLE
Switch to OpenJDK 8 rather than OracleJDK 8 in Travis CI because the …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 matrix:
   include:
     - os:  linux
-      jdk: oraclejdk8
+      jdk: openjdk8
       env: PYTHON=python3
     - os:  linux
       jdk: openjdk11


### PR DESCRIPTION
…latter is no longer supported