### PR TITLE
Make `checker.py script` Python 3 compatible

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -867,7 +867,7 @@ def getRunArgs(heap="$((HEAP))", _type="jar"):
 
 def generateRunScript():
     args = getRunArgs()
-    f = open(os.path.join(buildRoot, "run-validator.sh"), 'wb')
+    f = open(os.path.join(buildRoot, "run-validator.sh"), 'w')
     f.write("#!/bin/sh\n")
     if heapSize.startswith('-'):
         f.write("HEAP=`grep MemTotal /proc/meminfo | awk '{print $2}'`\n")


### PR DESCRIPTION
I'm currently migrating to Python 3 on a server and found a remaining incompatibility. This PR fixes it.

Writing str to a file in binary mode is not allowed in Python 3.
The run-validator.sh is a text file so that we should open it in text mode.