### PR TITLE
Travis variable cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,37 +12,36 @@ env:
     - TOMCAT_VERSION=8.5.29
     - CHECKER_PY=./checker.py
     - TRAVIS_TAG=linux
+    - PYTHON=python3
 
 matrix:
   include:
     - os:  linux
       jdk: openjdk8
-      env: PYTHON=python3
     - os:  linux
-      jdk: openjdk11
-      env: TRAVIS_TAG=jar
-    - os:  linux
-      jdk: openjdk11
-      env: TRAVIS_TAG=war
-    - os:  linux
-      jdk: openjdk11
-      env: PYTHON=python3
-    - os:  osx
       jdk: openjdk11
       env:
-        - PYTHON=python3
-        - TRAVIS_TAG=osx
+        - TRAVIS_TAG=jar
+        - PYTHON=python
+    - os:  linux
+      jdk: openjdk11
+      env:
+        - TRAVIS_TAG=war
+        - PYTHON=python
+    - os:  linux
+      jdk: openjdk11
+    - os:  osx
+      jdk: openjdk11
+      env: TRAVIS_TAG=osx
     - os:  linux
       jdk: openjdk13
-      env: PYTHON=python3
     - os:  linux
       jdk: openjdk14
-      env: PYTHON=python3
     - os:  linux
       jdk: openjdk-ea
-      env: PYTHON=python3
 
 install:
+  - $PYTHON --version
   - $PYTHON $CHECKER_PY update
   - travis_retry $PYTHON $CHECKER_PY dldeps
   - curl -O https://archive.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.zip
@@ -50,7 +49,6 @@ install:
   - chmod a+x apache-tomcat-$TOMCAT_VERSION/bin/*.sh
 
 script:
-  - if [ -z "$PYTHON" ]; then python --version; else $PYTHON --version; fi
   - $PYTHON $CHECKER_PY build
   - $PYTHON $CHECKER_PY jar
   - java -jar ./build/dist/vnu.jar ./build/dist/index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
     - TOMCAT_VERSION=8.5.29
     - CHECKER_PY=./checker.py
+    - TRAVIS_TAG=linux
 
 matrix:
   include:
@@ -19,16 +20,18 @@ matrix:
       env: PYTHON=python3
     - os:  linux
       jdk: openjdk11
-      env: JAR_DEPLOY=Yes
+      env: TRAVIS_TAG=jar
     - os:  linux
       jdk: openjdk11
-      env: WAR_DEPLOY=Yes
+      env: TRAVIS_TAG=war
     - os:  linux
       jdk: openjdk11
       env: PYTHON=python3
     - os:  osx
       jdk: openjdk11
-      env: PYTHON=python3
+      env:
+        - PYTHON=python3
+        - TRAVIS_TAG=osx
     - os:  linux
       jdk: openjdk13
       env: PYTHON=python3
@@ -93,9 +96,6 @@ before_deploy:
   - ls -al build/dist-war
   - git config --local user.name "Travis CI"
   - git config --local user.email "mike@w3.org"
-  - if [[ "$(uname)" == "Darwin" ]]; then TRAVIS_TAG="osx"; else TRAVIS_TAG="linux"; fi; export TRAVIS_TAG
-  - if [[ $JAR_DEPLOY == "Yes" ]]; then TRAVIS_TAG="jar"; fi; export TRAVIS_TAG
-  - if [[ $WAR_DEPLOY == "Yes" ]]; then TRAVIS_TAG="war"; fi; export TRAVIS_TAG
   - git push --delete git@github.com:validator/validator.git $TRAVIS_TAG || true
   - git tag -m $TRAVIS_TAG -f $TRAVIS_TAG -s --local-user 0x6C976B92
 
@@ -107,7 +107,7 @@ deploy:
     skip_cleanup: true
     file: "build/dist/{*.jar*}"
     on:
-      condition: $JAR_DEPLOY = "Yes"
+      condition: $TRAVIS_TAG = "jar"
       repo: validator/validator
       jdk: openjdk11
     api_key:
@@ -119,7 +119,7 @@ deploy:
     skip_cleanup: true
     file: "build/dist-war/{*.war*}"
     on:
-      condition: $WAR_DEPLOY = "Yes"
+      condition: $TRAVIS_TAG = "war"
       repo: validator/validator
       jdk: openjdk11
     api_key:
@@ -131,7 +131,7 @@ deploy:
     skip_cleanup: true
     file: "build/dist/{*.zip*}"
     on:
-      condition: $JAR_DEPLOY != "Yes" && $WAR_DEPLOY != "Yes"
+      condition: $TRAVIS_TAG != "jar" && $TRAVIS_TAG != "war"
       repo: validator/validator
       jdk: openjdk11
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ branches:
   except:
     - /^(osx|linux|windows|jar|war)$/
 
+env:
+  global:
+    - TOMCAT_VERSION=8.5.29
+    - CHECKER_PY=./checker.py
+
 matrix:
   include:
     - os:  linux
@@ -35,8 +40,6 @@ matrix:
       env: PYTHON=python3
 
 install:
-  - export TOMCAT_VERSION=8.5.29
-  - export CHECKER_PY=./checker.py
   - $PYTHON $CHECKER_PY update
   - travis_retry $PYTHON $CHECKER_PY dldeps
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ matrix:
 install:
   - $PYTHON $CHECKER_PY update
   - travis_retry $PYTHON $CHECKER_PY dldeps
+  - curl -O https://archive.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.zip
+  - unzip apache-tomcat-$TOMCAT_VERSION.zip
+  - chmod a+x apache-tomcat-$TOMCAT_VERSION/bin/*.sh
 
 script:
   - if [ -z "$PYTHON" ]; then python --version; else $PYTHON --version; fi
@@ -53,9 +56,6 @@ script:
   - $PYTHON $CHECKER_PY runtime-image
   - $PYTHON $CHECKER_PY war
   - jar xf ./build/dist-war/vnu.war && file WEB-INF/classes/nu/validator/servlet/VerifierServlet.class | grep "version 52.0"
-  - curl -O https://archive.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.zip
-  - unzip apache-tomcat-$TOMCAT_VERSION.zip
-  - chmod a+x apache-tomcat-$TOMCAT_VERSION/bin/*.sh
   - apache-tomcat-$TOMCAT_VERSION/bin/catalina.sh start
   - cp ./build/dist-war/vnu.war apache-tomcat-$TOMCAT_VERSION/webapps/
   - sleep 15s; tail apache-tomcat-$TOMCAT_VERSION/logs/catalina.out || true


### PR DESCRIPTION
Was reading through to see if I could figure out a cron for the Docker and found a few of the indirect variables a little hard to follow.
- Pulls up all the in-line `export` to global or matrix variables
- Pulls Tomcat setup into the `install` step

I think you have some logic encrypted in `resources/ssh_travis.enc` so maybe I'm missing part of the need for some of the variables