### PR TITLE
chore: Merge to single GitHub release for publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ git:
 
 branches:
   except:
-    - /^(osx|linux|windows|jar|war)$/
+    - /^(osx|linux|windows|jar|war|develop)$/
 
 env:
   global:
@@ -94,11 +94,12 @@ before_deploy:
   - ls -al build/dist-war
   - git config --local user.name "Travis CI"
   - git config --local user.email "mike@w3.org"
-  - git push --delete git@github.com:validator/validator.git $TRAVIS_TAG || true
-  - git tag -m $TRAVIS_TAG -f $TRAVIS_TAG -s --local-user 0x6C976B92
+  - git push --delete git@github.com:validator/validator.git develop || true
+  - git tag -m develop -f develop -s --local-user 0x6C976B92
 
 deploy:
   - provider: releases
+    tag_name: develop
     overwrite: true
     prerelease: true
     file_glob: true
@@ -111,6 +112,7 @@ deploy:
     api_key:
       secure: "Rx95y6BDpQSCPkWr8FqUByet61U7z1Tqo3KrRm2AN2MLbch9YcX8KScvH3Mmtk3wEsdOTsgLt6SYxBrU/7RKLKlvUTaIRFecQm/hZuhThLcd91q40Oy3KcedSsUUaYljRbvg/nh6MeloVOvDM5VitqV07NwykA0pVrSqoFJDBHA="
   - provider: releases
+    tag_name: develop
     overwrite: true
     prerelease: true
     file_glob: true
@@ -123,6 +125,7 @@ deploy:
     api_key:
       secure: "Rx95y6BDpQSCPkWr8FqUByet61U7z1Tqo3KrRm2AN2MLbch9YcX8KScvH3Mmtk3wEsdOTsgLt6SYxBrU/7RKLKlvUTaIRFecQm/hZuhThLcd91q40Oy3KcedSsUUaYljRbvg/nh6MeloVOvDM5VitqV07NwykA0pVrSqoFJDBHA="
   - provider: releases
+    tag_name: develop
     overwrite: true
     prerelease: true
     file_glob: true


### PR DESCRIPTION
Creates a single "develop" pre-release tag and upload all assets to tag.

- This will require updated the Dockerfile since it's using the platform specific tag. I'd probably do a second pass after this to ensure the version number tags also get populated with these assets, and use those as the Dockerfile assets.

- Appveyor would also needed to be updated to include the Windows assets.

Maybe you ran into an issue with this type of setup originally, so I'm fine if you don't like this approach and just want to close it.