### PR TITLE
Updated aria-dropeffect fix

### DIFF
--- a/schema/html5/aria.rnc
+++ b/schema/html5/aria.rnc
@@ -286,8 +286,9 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 
 ## dropeffect
 	aria.state.dropeffect =
-		attribute aria-dropeffect {
-			string
+		attribute aria-dropeffect
+			{	
+				list { ("copy" | "execute" | "link" | "move" | "none" | "popup") + } 
 		}
 
 ## expanded


### PR DESCRIPTION
This is an update to the fix I suggested in issue https://github.com/validator/validator/issues/915

After I reported the issue I discovered some ACT Rules test cases for both valid and invalid `aria-dropeffect` values:
https://act-rules.github.io/rules/6a7281#passed-example-9
https://act-rules.github.io/rules/6a7281#failed-example-8

This patch should now correctly check invalid and valid values per ARIA 1.1