### PR TITLE
Add missing DPUB-ARIA roles

### DIFF
--- a/schema/html5/embed.rnc
+++ b/schema/html5/embed.rnc
@@ -50,6 +50,7 @@ namespace local = ""
 			|	common.attrs.aria.role.switch
 			|	common.attrs.aria.role.tab
 			|	common.attrs.aria.role.treeitem
+			|	common.attrs.aria.role.doc-cover
 			)?
 		)
 

--- a/schema/html5/structural.rnc
+++ b/schema/html5/structural.rnc
@@ -40,6 +40,7 @@
 			|	common.attrs.aria.role.doc-credits
 			|	common.attrs.aria.role.doc-dedication
 			|	common.attrs.aria.role.doc-endnotes
+			|	common.attrs.aria.role.doc-epigraph
 			|	common.attrs.aria.role.doc-epilogue
 			|	common.attrs.aria.role.doc-errata
 			|	common.attrs.aria.role.doc-example


### PR DESCRIPTION
Makes the following changes as noted in the respective updates to the HTML in ARIA spec:

- adds doc-cover to allowed roles for img per https://github.com/w3c/html-aria/issues/230; and
- adds doc-epigraph to allowed roles for section per https://github.com/w3c/html-aria/issues/177