### PR TITLE
Url list option

### DIFF
--- a/src/nu/validator/client/SimpleCommandLineValidator.java
+++ b/src/nu/validator/client/SimpleCommandLineValidator.java
@@ -269,7 +269,7 @@ public class SimpleCommandLineValidator {
                                 + " requires a URL for a schema.");
                         System.exit(1);
                     }
-				} else if ("--file_url_list".equals(args[i])) {
+				} else if ("--file-url-list".equals(args[i])) {
                     fileNameWithFileList = args[++i];
 					hasFileList = true;
                 }					


### PR DESCRIPTION
adding an option --url_list FILENAME to check files (urls) specified in file FILENAME where each line of the file contains a file (URL). If the option is set checker validates both the files in this file and the ones specified in command-line arguments. That allows start vnu.jar only once to check any numbers of pages.

Also adding in cli-help:
#### --url_list _FILENAME_

    Specifies a filename with files (URLs) to be checked. Each line of the 
    file contains a file (URL). If the option is set checker validates both 
    the files in this file and the ones specified in command-line arguments.

    default: [unset; vnu validates only files (URLs) specified after all the 
    options or in standard input]    


