### PR TITLE
allow doc-glossary on section

### DIFF
--- a/schema/html5/structural.rnc
+++ b/schema/html5/structural.rnc
@@ -45,6 +45,7 @@
 			|	common.attrs.aria.role.doc-errata
 			|	common.attrs.aria.role.doc-example
 			|	common.attrs.aria.role.doc-foreword
+			|	common.attrs.aria.role.doc-glossary
 			|	common.attrs.aria.role.doc-index
 			|	common.attrs.aria.role.doc-introduction
 			|	common.attrs.aria.role.doc-notice


### PR DESCRIPTION
Per the [ARIA in HTML doc](https://www.w3.org/TR/html-aria/#el-section), doc-glossary should be allowed on section.