### PR TITLE
add doc-dedication to aside roles

### DIFF
--- a/schema/html5/structural.rnc
+++ b/schema/html5/structural.rnc
@@ -116,6 +116,7 @@
 			|	common.attrs.aria.role.feed
 			|	common.attrs.aria.role.region
 			|	common.attrs.aria.role.presentation
+			|	common.attrs.aria.role.doc-dedication
 			|	common.attrs.aria.role.doc-example
 			|	common.attrs.aria.role.doc-footnote
 			|	common.attrs.aria.role.doc-pullquote


### PR DESCRIPTION
Found one more omission from ARIA in HTML: doc-dedication is [allowed on aside](https://www.w3.org/TR/html-aria/#el-aside).

I set up tests for all the elements and their allowed dpub-aria roles and this was the only new error I found, so everything should be good now.