### PR TITLE
allow rel on svg a element

### DIFF
--- a/schema/svg11/svg-hyperlink.rnc
+++ b/schema/svg11/svg-hyperlink.rnc
@@ -65,5 +65,6 @@ grammar {
         SVG.External.attrib,
         (common.attrs.aria.implicit.link | common.attrs.aria)?,
         attribute transform { TransformList.datatype }?,
-        attribute target { LinkTarget.datatype }?
+        attribute target { LinkTarget.datatype }?,
+        attribute rel { string }?
 }


### PR DESCRIPTION
Updates the schema to allow a `rel` attribute on `a` elements as requested in #1008.

I took a look at the java code for validating the tokens, but as far as I can tell (being no java developer), the existing processing of `a` attributes should cover this once allowed. If I've got that wrong, just let me know where I should be looking to enable it.