### PR TITLE
CI: Refactor macOS/Linux builds; add release automation

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,28 @@
+name: 'Build'
+runs:
+  using: "composite"
+  steps:
+    - id: build
+      env:
+        TOMCAT_VERSION: 8.5.29
+      shell: bash
+      run: |
+        python ./checker.py build
+        python ./checker.py jar
+        python ./checker.py image
+        python ./checker.py war
+        java -jar ./build/dist/vnu.jar ./build/dist/index.html
+        java -jar ./build/dist/vnu.jar ./site/nu-about.html
+        jar xf ./build/dist/vnu.jar && javap -verbose nu/validator/client/SimpleCommandLineValidator.class | grep "major version: 52"
+        curl -O https://archive.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.zip
+        unzip apache-tomcat-$TOMCAT_VERSION.zip
+        chmod a+x apache-tomcat-$TOMCAT_VERSION/bin/*.sh
+        jar xf ./build/dist-war/vnu.war && javap -verbose WEB-INF/classes/nu/validator/servlet/VerifierServlet.class | grep "major version: 52"
+        apache-tomcat-$TOMCAT_VERSION/bin/catalina.sh start
+        cp ./build/dist-war/vnu.war apache-tomcat-$TOMCAT_VERSION/webapps/
+        sleep 15s; tail apache-tomcat-$TOMCAT_VERSION/logs/catalina.out || true
+        curl -sS 'http://localhost:8080/vnu/?out=gnu&doc=data:text/html;charset=utf-8,%3C%21doctype%20html%3E%3Cmeta%20charset%3Dutf-8%3E%3Ctitle%3ETest%3C%2Ftitle%3E' > RESULTS
+        test -z "$(if [ -t RESULTS ]; then cat RESULTS | grep -v '^$'; fi)"
+        if [ $? != 0 ]; then cat RESULTS; fi
+        python ./checker.py check
+        python ./checker.py test

--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -2,8 +2,7 @@ name: macOS build for vnu
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/**"
+    branches: [main]
   pull_request:
 
 jobs:
@@ -11,50 +10,40 @@ jobs:
     runs-on: macos-latest
     strategy:
       fail-fast: false
-      matrix:
-        java:
-        - 11
-
     steps:
-    - uses: actions/checkout@v2
-    # - name: Setup Java JDK
-    #   uses: actions/setup-java@v2
-    #   with:
-    #     distribution: adopt
-    #     java-version: ${{ matrix.java }}
-    # - uses: actions/setup-python@v2
-    #   with:
-    #     python-version: '3.x'
-    # - name: Update Submodules
-    #   run: python ./checker.py update
-    # - name: Install Dependencies
-    #   run: python ./checker.py dldeps
-    # - name: Build
-    #   env:
-    #     TOMCAT_VERSION: 8.5.29
-    #   run: |
-    #     python ./checker.py build
-    #     python ./checker.py jar
-    #     python ./checker.py image
-    #     python ./checker.py war
-    #     java -jar ./build/dist/vnu.jar ./build/dist/index.html
-    #     java -jar ./build/dist/vnu.jar ./site/nu-about.html
-    #     curl -O https://archive.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.zip
-    #     unzip apache-tomcat-$TOMCAT_VERSION.zip
-    #     chmod a+x apache-tomcat-$TOMCAT_VERSION/bin/*.sh
-    #     jar xf ./build/dist/vnu.jar && file nu/validator/client/SimpleCommandLineValidator.class | grep "version 52.0"
-    #     jar xf ./build/dist-war/vnu.war && file WEB-INF/classes/nu/validator/servlet/VerifierServlet.class | grep "version 52.0"
-    #     apache-tomcat-$TOMCAT_VERSION/bin/catalina.sh start
-    #     cp ./build/dist-war/vnu.war apache-tomcat-$TOMCAT_VERSION/webapps/
-    #     sleep 15s; tail apache-tomcat-$TOMCAT_VERSION/logs/catalina.out || true
-    #     curl -sS 'http://localhost:8080/vnu/?out=gnu&doc=data:text/html;charset=utf-8,%3C%21doctype%20html%3E%3Cmeta%20charset%3Dutf-8%3E%3Ctitle%3ETest%3C%2Ftitle%3E' > RESULTS
-    #     test -z "$(if [ -t RESULTS ]; then cat RESULTS | grep -v '^$'; fi)"
-    #     if [ $? != 0 ]; then cat RESULTS; fi
-    #     python ./checker.py check
-    #     python ./checker.py test
-    # - uses: actions/upload-artifact@v2
-    #   if: matrix.java == 11
-    #   with:
-    #     # Currently creates a nested zip https://github.com/actions/upload-artifact/issues/3
-    #     name: vnu.osx.zip
-    #     path: "build/dist/vnu.osx.zip"
+      - uses: actions/checkout@v2
+      - name: Set up Java JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 16
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Update submodules
+        run: python ./checker.py update
+      - name: Install dependencies
+        run: python ./checker.py dldeps
+      - name: Build
+        uses: ./.github/actions/build
+      - name: Import GPG signing key
+        uses: crazy-max/ghaction-import-gpg@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
+          git-user-signingkey: true
+          git-commit-gpgsign: true
+      - name: Sign release artifacts
+        if: github.ref == 'refs/heads/main'
+        run: |
+          for file in build/dist/{*.zip,*.zip.md5,*.zip.sha1}; do gpg --yes -ab --sign $file; done || true
+          for file in build/dist/*.jar*; do gpg --yes -ab --sign $file; done || true
+          for file in build/dist-war/*.war*; do gpg --yes -ab --sign $file; done || true
+      - name: Release new macOS binary image
+        uses: "marvinpinto/action-automatic-releases@latest"
+        if: github.ref == 'refs/heads/main'
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "osx"
+          files: build/dist/*.zip*

--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -41,9 +41,15 @@ jobs:
           for file in build/dist/*.jar*; do gpg --yes -ab --sign $file; done || true
           for file in build/dist-war/*.war*; do gpg --yes -ab --sign $file; done || true
       - name: Release new macOS binary image
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: ncipollo/release-action@v1.8.6
         if: github.ref == 'refs/heads/main'
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "osx"
-          files: build/dist/*.zip*
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit: ${{ github.sha }}
+          allowUpdates: true
+          artifacts: build/dist/*.zip*
+          body: ${{ github.sha }} — ${{ github.event.head_commit.message }}
+          name: latest
+          omitName: true
+          prerelease: true
+          tag: latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -60,10 +60,16 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "jar"
           files: build/dist/*.jar*
-      - name: Release new war
-        uses: "marvinpinto/action-automatic-releases@latest"
+      - name: Release new jar, war, and Linux binary runtime image
+        uses: ncipollo/release-action@v1.8.6
         if: matrix.java == 16 && github.ref == 'refs/heads/main'
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "war"
-          files: build/dist-war/*.war*
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit: ${{ github.sha }}
+          allowUpdates: true
+          artifacts: build/dist/*.zip*,*build/dist/*.jar*,build/dist-war/*.war*
+          body: ${{ github.sha }} — ${{ github.event.head_commit.message }}
+          name: latest
+          omitName: true
+          prerelease: true
+          tag: latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,8 +2,7 @@ name: Linux build for vnu
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/**"
+    branches: [main]
   pull_request:
 
 jobs:
@@ -13,70 +12,58 @@ jobs:
       fail-fast: false
       matrix:
         java:
-        - 8
-        - 11
-        - 13
-        - 14-ea
-        - 15-ea
-
+          - 16
+          - 11
+          - 8
+          - 17-ea
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Java JDK
-      uses: actions/setup-java@v2
-      with:
-        distribution: adopt
-        java-version: ${{ matrix.java }}
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Update Submodules
-      run: python ./checker.py update
-    - name: Install Dependencies
-      run: python ./checker.py dldeps
-    - name: Build
-      env:
-        TOMCAT_VERSION: 8.5.29
-      run: |
-        python ./checker.py build
-        python ./checker.py jar
-        python ./checker.py image
-        python ./checker.py war
-        java -jar ./build/dist/vnu.jar ./build/dist/index.html
-        java -jar ./build/dist/vnu.jar ./site/nu-about.html
-        jar xf ./build/dist/vnu.jar && file nu/validator/client/SimpleCommandLineValidator.class | grep "version 52.0"
-        curl -O https://archive.apache.org/dist/tomcat/tomcat-8/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.zip
-        unzip apache-tomcat-$TOMCAT_VERSION.zip
-        chmod a+x apache-tomcat-$TOMCAT_VERSION/bin/*.sh
-        jar xf ./build/dist-war/vnu.war && file WEB-INF/classes/nu/validator/servlet/VerifierServlet.class | grep "version 52.0"
-        apache-tomcat-$TOMCAT_VERSION/bin/catalina.sh start
-        cp ./build/dist-war/vnu.war apache-tomcat-$TOMCAT_VERSION/webapps/
-        sleep 15s; tail apache-tomcat-$TOMCAT_VERSION/logs/catalina.out || true
-        curl -sS 'http://localhost:8080/vnu/?out=gnu&doc=data:text/html;charset=utf-8,%3C%21doctype%20html%3E%3Cmeta%20charset%3Dutf-8%3E%3Ctitle%3ETest%3C%2Ftitle%3E' > RESULTS
-        test -z "$(if [ -t RESULTS ]; then cat RESULTS | grep -v '^$'; fi)"
-        if [ $? != 0 ]; then cat RESULTS; fi
-        python ./checker.py check
-        python ./checker.py test
-    - uses: actions/upload-artifact@v2
-      if: matrix.java == 11
-      with:
-        name: vnu.jar
-        path: "build/dist/vnu.jar"
-    - uses: actions/upload-artifact@v2
-      if: matrix.java == 11
-      with:
-        name: vnu.war
-        path: "build/dist-war/vnu.war"
-    - uses: actions/upload-artifact@v2
-      if: matrix.java == 11
-      with:
-        # Currently creates a nested zip https://github.com/actions/upload-artifact/issues/3
-        name: vnu.linux.zip
-        path: "build/dist/vnu.linux.zip"
-    - uses: "marvinpinto/action-automatic-releases@latest"
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "jar2"
-        prerelease: true
-        title: "jar"
-        files: |
-          build/dist/*.jar*
+      - uses: actions/checkout@v2
+      - name: Set up Java JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: ${{ matrix.java }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Update submodules
+        run: python ./checker.py update
+      - name: Install dependencies
+        run: python ./checker.py dldeps
+      - name: Build
+        uses: ./.github/actions/build
+      - name: Import GPG signing key
+        uses: crazy-max/ghaction-import-gpg@v3
+        if: matrix.java == 16 && github.ref == 'refs/heads/main'
+        with:
+          gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
+          git-user-signingkey: true
+          git-commit-gpgsign: true
+      - name: Sign release artifacts
+        if: matrix.java == 16 && github.ref == 'refs/heads/main'
+        run: |
+          for file in build/dist/{*.zip,*.zip.md5,*.zip.sha1}; do gpg --yes -ab --sign $file; done || true
+          for file in build/dist/*.jar*; do gpg --yes -ab --sign $file; done || true
+          for file in build/dist-war/*.war*; do gpg --yes -ab --sign $file; done || true
+      - name: Release new linux binary image
+        uses: "marvinpinto/action-automatic-releases@latest"
+        if: matrix.java == 16 && github.ref == 'refs/heads/main'
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "linux"
+          files: build/dist/*.zip*
+      - name: Release new jar
+        uses: "marvinpinto/action-automatic-releases@latest"
+        if: matrix.java == 16 && github.ref == 'refs/heads/main'
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "jar"
+          files: build/dist/*.jar*
+      - name: Release new war
+        uses: "marvinpinto/action-automatic-releases@latest"
+        if: matrix.java == 16 && github.ref == 'refs/heads/main'
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "war"
+          files: build/dist-war/*.war*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,8 +2,7 @@ name: Windows build for vnu
 
 on:
   push:
-    branches-ignore:
-      - "dependabot/**"
+    branches: [main]
   pull_request:
 
 jobs:
@@ -11,41 +10,44 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      matrix:
-        java:
-        - 8
-        - 11
-        - 13
-        - 14-ea
-        - 15-ea
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Java JDK
-      uses: actions/setup-java@v2
-      with:
-        distribution: adopt
-        java-version: ${{ matrix.java }}
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Update Submodules
-      run: python .\checker.py update
-    - name: Install Dependencies
-      run: python .\checker.py dldeps
-    - name: Build
-      run: |
-        python .\checker.py build
-        python .\checker.py jar
-        python .\checker.py image
-        python .\checker.py war
-        java -jar .\build\dist\vnu.jar .\build\dist\index.html
-        java -jar .\build\dist\vnu.jar .\site\nu-about.html
-        python .\checker.py check
-        python .\checker.py test
-    - uses: actions/upload-artifact@v2
-      if: matrix.java == 11
-      with:
-        # Currently creates a nested zip https://github.com/actions/upload-artifact/issues/3
-        name: vnu.windows.zip
-        path: "build/dist/vnu.windows.zip"
+      - uses: actions/checkout@v2
+      - name: Set up Java JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 16
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Update submodules
+        run: python .\checker.py update
+      - name: Install dependencies
+        run: python .\checker.py dldeps
+      - name: Build
+        run: |
+          python .\checker.py build
+          python .\checker.py jar
+          python .\checker.py image
+          python .\checker.py war
+          java -jar .\build\dist\vnu.jar .\build\dist\index.html
+          java -jar .\build\dist\vnu.jar .\site\nu-about.html
+          python .\checker.py check
+          python .\checker.py test
+      - name: Import GPG signing key
+        uses: crazy-max/ghaction-import-gpg@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
+          git-user-signingkey: true
+          git-commit-gpgsign: true
+      - name: Sign release artifacts
+        if: github.ref == 'refs/heads/main'
+        run: bash -lc 'for file in build/dist/{*.zip,*.zip.md5,*.zip.sha1}; do gpg --yes -ab --sign $file; done || true'
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        if: github.ref == 'refs/heads/main'
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "windows"
+          files: build/dist/*.zip*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,9 +45,16 @@ jobs:
       - name: Sign release artifacts
         if: github.ref == 'refs/heads/main'
         run: bash -lc 'for file in build/dist/{*.zip,*.zip.md5,*.zip.sha1}; do gpg --yes -ab --sign $file; done || true'
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - name: Release new Windows binary image
+        uses: ncipollo/release-action@v1.8.6
         if: github.ref == 'refs/heads/main'
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "windows"
-          files: build/dist/*.zip*
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit: ${{ github.sha }}
+          allowUpdates: true
+          artifacts: build/dist/*.zip*
+          body: ${{ github.sha }} — ${{ github.event.head_commit.message }}
+          name: latest
+          omitName: true
+          prerelease: true
+          tag: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,8 @@ FROM debian:stable-slim AS builder
 LABEL name="vnu"
 LABEL version="dev"
 LABEL maintainer="Michael[tm] Smith <mike@w3.org>"
-ADD https://github.com/validator/validator/releases/download/linux/vnu.linux.zip .
-ADD https://github.com/validator/validator/releases/download/linux/vnu.linux.zip.asc .
-ADD https://github.com/validator/validator/releases/download/linux/vnu.linux.zip.sha1 .
-ADD https://github.com/validator/validator/releases/download/linux/vnu.linux.zip.sha1.asc .
+ADD https://github.com/validator/validator/releases/download/latest/vnu.linux.zip .
+ADD https://github.com/validator/validator/releases/download/latest/vnu.linux.zip.sha1 .
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install --no-install-recommends -y \
        unzip=6.0-23+deb10u2 \


### PR DESCRIPTION
This includes the following changes:

* factor out the common part of the macOS and Linux builds into a separate `.github/actions/build/action.yml` file

* add automation for releasing the jar and war files, as well as the Linux, macOS, and Windows binary runtime images

* fix a bug that was breaking the macOS build