### PR TITLE
Drop the `jar` and `linux` release tags

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,20 +46,6 @@ jobs:
           for file in build/dist/{*.zip,*.zip.md5,*.zip.sha1}; do gpg --yes -ab --sign $file; done || true
           for file in build/dist/*.jar*; do gpg --yes -ab --sign $file; done || true
           for file in build/dist-war/*.war*; do gpg --yes -ab --sign $file; done || true
-      - name: Release new linux binary image
-        uses: "marvinpinto/action-automatic-releases@latest"
-        if: matrix.java == 16 && github.ref == 'refs/heads/main'
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "linux"
-          files: build/dist/*.zip*
-      - name: Release new jar
-        uses: "marvinpinto/action-automatic-releases@latest"
-        if: matrix.java == 16 && github.ref == 'refs/heads/main'
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "jar"
-          files: build/dist/*.jar*
       - name: Release new jar, war, and Linux binary runtime image
         uses: ncipollo/release-action@v1.8.6
         if: matrix.java == 16 && github.ref == 'refs/heads/main'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ NN XXX NNNN
   - Update doc-fetching backend to Apache HTTP Components HttpClient 4.5.9
   - Make the checker use HTTP 1.0 for all requests it make, not HTTP 1.1
   - Make the checker ignore error for malformed/missing HTTP closing chunk
+  - Release: All autopublished-on-push release artifacts are now released
+    under the tag `latest`; no more `jar`, `war`, `windows`, `linux`, `osx`
 
 # 20.6.30
 30 June 2020


### PR DESCRIPTION
All autopublished-on-push release artifacts are now released under the tag `latest`; no more `jar`, `war`, `windows`, `linux`, `osx`