### PR TITLE
CI: switch to using tags consistently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
           for file in build/dist-war/*.war*; do gpg --yes -ab --sign $file; done || true
       - name: Release new binary runtime image
         if: matrix.java == 16 && github.ref == 'refs/heads/main'
-        uses: ncipollo/release-action@v1.8.9
+        uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit: ${{ github.sha }}
@@ -110,7 +110,7 @@ jobs:
           tag: latest
       - name: Release new jar and war
         if: matrix.os == 'ubuntu-latest' && matrix.java == 16 && github.ref == 'refs/heads/main'
-        uses: ncipollo/release-action@v1.8.9
+        uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -19,19 +19,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Log in to the container registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v3.5.0
+        uses: docker/metadata-action@v3
         with:
           images: ghcr.io/validator/validator
           tags: type=semver,pattern={{version}}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2.7.0
+        uses: docker/build-push-action@v2
         with:
           context: .
           push: true


### PR DESCRIPTION
This allows us to use the latest version of a specific tag without bumping the version for each minor/patch release.
