### PR TITLE
Adding fixed versions and the OpenJDK supporting that

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,20 +27,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [17, 11, 8, 16]
+        java: [17, 11.0.3, 8.0.192]
         exclude:
           - os: macos-latest
-            java: 8
+            java: 8.0.192
           - os: macos-latest
-            java: 11
-          - os: macos-latest
-            java: 16
+            java: 11.0.3
           - os: windows-latest
-            java: 8
+            java: 8.0.192
           - os: windows-latest
-            java: 11
-          - os: windows-latest
-            java: 16
+            java: 11.0.3
     steps:
       - uses: actions/checkout@v2
       - name: Set up Java JDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Java JDK
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: zulu
           java-version: ${{ matrix.java }}
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
For regression testing, it's useful to know that your code works against the latest JDK as well as fixed versions, adding fixed versions, also changing from 'adopt' (which no longer exists) to 'temurin' and from there to 'zulu', since Zulu has a history including minor JDK versions and a complete archive of JDKs versions.