### PR TITLE
update the allowed roles for wbr

### DIFF
--- a/schema/html5/phrase.rnc
+++ b/schema/html5/phrase.rnc
@@ -419,7 +419,7 @@ referrerpolicy =
 		element wbr { wbr.inner & wbr.attrs }
 	wbr.attrs =
 		(	common.attrs
-		&	common.attrs.aria?
+		&	common.attrs.aria.role.presentation?
 		)
 	wbr.inner =
 		( empty )


### PR DESCRIPTION
update allowed roles for `wbr` to match `br` element

related to #1241, but does not (presently) address updating `wbr` and `br` to only allow `aria-hidden`