### PR TITLE
remove deprecated dpub role allowances

### DIFF
--- a/schema/html5/block.rnc
+++ b/schema/html5/block.rnc
@@ -101,8 +101,6 @@ datatypes w = "http://whattf.org/datatype-draft"
 			|	common.attrs.aria.role.treeitem
 			|	common.attrs.aria.role.separator
 			|	common.attrs.aria.role.presentation
-			|	common.attrs.aria.role.doc-biblioentry
-			|	common.attrs.aria.role.doc-endnote
 			)?
 		)
 	li.inner =


### PR DESCRIPTION
Related to ARIA in HTML issue https://github.com/w3c/html-aria/pull/369

`doc-biblioentry` and `doc-endnote` are being deprecated from dpub ARIA 1.1 in favor of authors just using standard list / list item elements or roles.  ARIA in HTML is updating in kind.

Note: this PR is simply removing the dpub roles from the allowed roles for `li`.  If there is a warning that could be raised instead for these roles, that would be fine as well, and we could close this PR in favor of that.