### PR TITLE
adds role=radio alowance to img alt=foo

### DIFF
--- a/schema/html5/embed.rnc
+++ b/schema/html5/embed.rnc
@@ -44,6 +44,7 @@ namespace local = ""
 			|	common.attrs.aria.role.option
 			|	common.attrs.aria.role.presentation
 			|	common.attrs.aria.role.progressbar
+			|	common.attrs.aria.role.radio
 			|	common.attrs.aria.role.scrollbar
 			|	common.attrs.aria.role.separator
 			|	common.attrs.aria.role.slider


### PR DESCRIPTION
related to ARIA in HTML PR https://github.com/w3c/html-aria/pull/212, `role=radio` was meant to be kept as an allowance for an `img` with an accessible name, but it didn't make it into the spec.  

https://github.com/w3c/html-aria/pull/381 will add this allowance