### PR TITLE
update role allowances for button and input type=button

### DIFF
--- a/schema/html5/web-forms.rnc
+++ b/schema/html5/web-forms.rnc
@@ -166,7 +166,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
 			|	common.attrs.aria.role.checkbox
-			|       common.attrs.aria.role.combobox
+			|	common.attrs.aria.role.combobox
 			|	common.attrs.aria.role.link
 			|	common.attrs.aria.role.menuitem
 			|	common.attrs.aria.role.menuitemcheckbox

--- a/schema/html5/web-forms.rnc
+++ b/schema/html5/web-forms.rnc
@@ -165,6 +165,8 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	input.button.attrs.value? 
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
+			|	common.attrs.aria.role.checkbox
+			|       common.attrs.aria.role.combobox
 			|	common.attrs.aria.role.link
 			|	common.attrs.aria.role.menuitem
 			|	common.attrs.aria.role.menuitemcheckbox
@@ -457,6 +459,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
 			|	common.attrs.aria.role.checkbox
+			|	common.attrs.aria.role.combobox
 			|	common.attrs.aria.role.link
 			|	common.attrs.aria.role.menuitem
 			|	common.attrs.aria.role.menuitemcheckbox


### PR DESCRIPTION
[ARIA in HTML is planning to allow `role=combobox` on a `button` and `input type=button` element](https://github.com/w3c/html-aria/pull/396).  This PR updates the validator to allow this role on these elements.

Adds `role=combobox` as an allowed role for `button` and `input type=button`.

Additionally, this PR adds `role=checkbox` as an allowed role for `input type=button` to match the `button` element allowances.  This was an oversight in the spec which this PR will help correct.