### PR TITLE
feat: add support width and height of source in picture

### DIFF
--- a/schema/html5/embed.rnc
+++ b/schema/html5/embed.rnc
@@ -139,6 +139,8 @@ namespace local = ""
 		&	source.picture.attrs.srcset
 		&	source.picture.attrs.sizes?
 		&	source.picture.attrs.type?
+		&	source.picture.attrs.width?
+		&	source.picture.attrs.height?
 		)
 		source.picture.attrs.media =
 			attribute media {
@@ -155,6 +157,14 @@ namespace local = ""
 		source.picture.attrs.type =
 			attribute type {
 				common.data.mimetype
+			}
+		source.picture.attrs.width =
+			attribute width {
+				common.data.integer.non-negative
+			}
+		source.picture.attrs.height =
+			attribute height {
+				common.data.integer.non-negative
 			}
 	source.picture.inner =
 		( empty )


### PR DESCRIPTION
This PR makes Nu Html Checker accept `width` and `height` attributes of `source` element  when the parent is a `picture` element.

Fixes https://github.com/validator/validator/issues/1161

## References

[4.8.2 The source element](https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element)

> The [source](https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element) element supports [dimension attributes](https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes).

[4.8.18 Dimension attributes](https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes)

> Author requirements: The width and height attributes on ... [source](https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element) when the parent is a [picture](https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element) element .... The attributes, if specified, must have values that are [valid non-negative integers](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-non-negative-integer).

## Remaining tasks

Following files should be updated though I'm not familiar with them.

https://github.com/validator/tests/blob/master/html/elements/picture/source-height-novalid.html
https://github.com/validator/tests/blob/master/html/elements/picture/source-width-novalid.html