### PR TITLE
add enterkeyhint & improve inputmode

### DIFF
--- a/schema/html5/applications.rnc
+++ b/schema/html5/applications.rnc
@@ -10,8 +10,6 @@ datatypes w = "http://whattf.org/datatype-draft"
 		(	common.attrs.contenteditable?
 		&	common.attrs.draggable?
 		&	common.attrs.hidden?
-		&	common.attrs.spellcheck?
-		&	common.attrs.autocapitalize?
 		)
 		
 	common.attrs.other &= common.attrs.interact
@@ -37,10 +35,36 @@ datatypes w = "http://whattf.org/datatype-draft"
 			w:string "hidden" | w:string ""
 		}
 
+## Global attributes applicable on elements with editable content
+
+	common.attrs.editing &=
+		(	common.attrs.inputmode?
+		&	common.attrs.spellcheck?
+		&	common.attrs.autocapitalize?
+		&	common.attrs.enterkeyhint?
+		)
+		
+	common.attrs.other &= common.attrs.editing
+
+## Hint expected data type: inputmode
+
+	common.attrs.inputmode =
+		attribute inputmode {
+			(	w:string "none"
+			|	w:string "text"
+			|	w:string "tel"
+			|	w:string "url"
+			|	w:string "email"
+			|	w:string "numeric"
+			|	w:string "decimal"
+			|	w:string "search"
+			)
+		}
+
 ## Spellchecking and grammar checking: spellcheck
 
 	common.attrs.spellcheck =
-		attribute spellcheck{
+		attribute spellcheck {
 			w:string "true" | w:string "false" | w:string ""
 		}
 
@@ -54,6 +78,20 @@ datatypes w = "http://whattf.org/datatype-draft"
 			|	w:string "sentences"
 			|	w:string "words"
 			|	w:string "characters"
+			)
+		}
+
+## Type of Enter button on virtual keyboards: enterkeyhint
+
+	common.attrs.enterkeyhint =
+		attribute enterkeyhint {
+			(	w:string "enter"
+			|	w:string "done"
+			|	w:string "go"
+			|	w:string "next"
+			|	w:string "previous"
+			|	w:string "search"
+			|	w:string "send"
 			)
 		}
 

--- a/schema/html5/common.rnc
+++ b/schema/html5/common.rnc
@@ -202,18 +202,12 @@ common.attrs.present =
 
 common.attrs.other =
 	(	common.attrs.autofocus?
-	&	common.attrs.inputmode?
 	&	common.attrs.nonce?
 	)
 
 	common.attrs.autofocus = 
 		attribute autofocus {
 			w:string "autofocus" | w:string ""
-		}
-
-	common.attrs.inputmode =
-		attribute inputmode {
-			string
 		}
 
 	common.attrs.nonce =

--- a/schema/html5/embed.rnc
+++ b/schema/html5/embed.rnc
@@ -321,6 +321,7 @@ namespace local = ""
 			                    | aria-roledescription
 			                    | spellcheck
 			                    | autocapitalize
+			                    | enterkeyhint
 			                    | accesskey
 			                    | itemref
 			                    | itemprop


### PR DESCRIPTION
This PR adds [enterkeyhint](https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-enterkeyhint-attribute) global attribute and also makes [inputmode](https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute) accept only known values rather than any string. I also grouped all global attributes which are useful only when element is editable.

Fixes #831 
Fixes #1126 