### PR TITLE
Remove manifest attribute

### DIFF
--- a/schema/html5/applications.rnc
+++ b/schema/html5/applications.rnc
@@ -57,15 +57,6 @@ datatypes w = "http://whattf.org/datatype-draft"
 			)
 		}
 
-## Application Cache: manifest
-
-	html.attrs.manifest =
-		attribute manifest {
-			common.data.uri.non-empty
-		}
-		
-	html.attrs &= html.attrs.manifest?
-
 ## Progess Indicator: <progress>
 
 	progress.elem =

--- a/src/nu/validator/checker/ConformingButObsoleteWarner.java
+++ b/src/nu/validator/checker/ConformingButObsoleteWarner.java
@@ -59,11 +59,6 @@ public class ConformingButObsoleteWarner extends Checker {
                         + " Consider putting an \u201Cid\u201D attribute"
                         + " on the nearest container instead.");
                 }
-            } else if ("html" == localName) {
-                if (atts.getIndex("", "manifest") > -1) {
-                    warn("The manifest-based application cache feature is"
-                        + " obsolete. Consider using service workers instead.");
-                }
             }
         }
     }


### PR DESCRIPTION
Removes manifest attribute from html element. It was part of AppCache, [removed in 2020](https://github.com/whatwg/html/commit/e4330d510a1d05e1f5f84707c9d6dcec97db94b8).

I tried to remove MANIFEST from AttributeName class, but for a reason I don't understand, a lot of tests started to fail with those messages:
```
warning: Attribute "xlink:href" is not serializable as XML 1.0.
error: Attribute "xlink:href" not allowed on element "use" at this point.
```

Fixes #1050 