### PR TITLE
Corrected possible attributes for input elements

### DIFF
--- a/schema/html5/web-forms.rnc
+++ b/schema/html5/web-forms.rnc
@@ -4,12 +4,55 @@ datatypes w = "http://whattf.org/datatype-draft"
 ##  RELAX NG Schema for HTML 5: Web Forms 1.0 markup                  #
 # #####################################################################
 
-## Shared attributes for form controls
+## Groups of shared attributes
 
+# Shared by all form controls
 	common-form.attrs =
 		(	common-form.attrs.name?
 		&	common-form.attrs.disabled?
+		&	common-form.attrs.form?
 		)
+
+# Shared by all single or multiple line text edit controls
+	shared-form.attrs.text-edit =
+		(	common-form.attrs
+		&	shared-form.attrs.minlength?
+		&	shared-form.attrs.maxlength?
+		&	shared-form.attrs.required?
+		&	shared-form.attrs.readonly?
+		)
+
+# Shared by all single-line text edit controls
+	shared-form.attrs.single-line-text-edit =
+		(	shared-form.attrs.text-edit
+		&	input.attrs.autocomplete?
+		&	shared-form.attrs.placeholder?
+		&	aria.prop.placeholder?
+		&	shared-form.attrs.pattern?
+		&	shared-form.attrs.size?
+		)
+
+# Shared by all date & time controls
+	shared-form.attrs.date-time =
+		(	common-form.attrs?
+		&	input.attrs.autocomplete?
+		&	input.attrs.list?
+		&	shared-form.attrs.required?
+		&	aria.prop.required?
+		&	shared-form.attrs.readonly?
+		)
+
+# Shared by all buttons able to submit the form
+	shared-form.attrs.submit = 
+		(	common-form.attrs?
+		&	shared-form.attrs.formaction?
+		&	shared-form.attrs.formenctype?
+		&	shared-form.attrs.formmethod?
+		&	shared-form.attrs.formtarget?
+		&	shared-form.attrs.formnovalidate?
+		)
+
+## Shared attributes by all form controls
 		
 	common-form.attrs.name = 
 		attribute name {
@@ -21,14 +64,60 @@ datatypes w = "http://whattf.org/datatype-draft"
 			w:string "disabled" | w:string ""
 		}
 
+	common-form.attrs.form |= 
+		attribute form {
+			common.data.idref
+		}
+		
+## Shared attributes by most of control fields
+
+	input.attrs.autocomplete.any =
+		attribute autocomplete {
+			(	w:string "on" | w:string "off"
+			|	common.data.autocomplete.any
+			)
+		}
+
+	input.attrs.autocomplete =
+		attribute autocomplete {
+			string
+		}
+
+	input.attrs.list = 
+		attribute list {
+			common.data.idref
+		}
+
+	shared-form.attrs.required = 
+		attribute required {
+			w:string "required" | w:string ""
+		}
+
 	shared-form.attrs.readonly = 
 		attribute readonly {
 			w:string "readonly" | w:string ""
 		}
 
+## Shared attributes by all single-line text control fields
+
+	shared-form.attrs.minlength =
+		attribute minlength {
+			common.data.integer.non-negative
+		}
+
 	shared-form.attrs.maxlength = 
 		attribute maxlength {
 			common.data.integer.non-negative
+		}
+
+	shared-form.attrs.pattern = 
+		attribute pattern {
+			form.data.pattern
+		}
+
+	shared-form.attrs.placeholder = 
+		attribute placeholder {
+			form.data.stringwithoutlinebreaks
 		}
 
 	shared-form.attrs.size = 
@@ -38,11 +127,68 @@ datatypes w = "http://whattf.org/datatype-draft"
 	
 	# REVISIT tabindex goes in common.attrs
 
-## Shared attributes for <input>
+## Shared attributes by buttons able to submit the form
+
+	shared-form.attrs.formaction =
+		attribute formaction {
+			common.data.uri.non-empty
+		}
+
+	shared-form.attrs.formenctype =
+		attribute formenctype {
+			shared-form.attrs.formenctype.data
+		}
+		shared-form.attrs.formenctype.data = 
+			(	w:string "application/x-www-form-urlencoded" 
+			|	w:string "multipart/form-data"
+			|	w:string "text/plain"
+			)
+
+	shared-form.attrs.formmethod =
+		attribute formmethod {
+			shared-form.attrs.formmethod.data
+		}
+		shared-form.attrs.formmethod.data = 
+			( w:string "get"
+			| w:string "post"
+			| w:string "dialog"
+			)
+
+	shared-form.attrs.formtarget = 
+		attribute formtarget {
+			common.data.browsing-context-or-keyword
+		}
+
+	shared-form.attrs.formnovalidate = 
+		attribute formnovalidate {
+			w:string "formnovalidate" | w:string ""
+		}
+
+## Other shared attributes
 	
 	input.attrs.checked = 
 		attribute checked {
 			w:string "checked" | w:string ""
+		}
+
+	shared-form.attrs.dirname = 
+		attribute dirname {
+			form.data.nonemptystring
+		}
+
+	input.attrs.multiple = 
+		attribute multiple {
+			w:string "multiple" | w:string ""
+		}
+
+	input.attrs.step.float = 
+		attribute step {
+			w:string "any" | common.data.float.positive
+		}
+
+	input.attrs.step.integer = 
+		attribute step {
+			w:string "any" | common.data.integer.positive 
 		}
 
 ## Text Field: <input type='text'>
@@ -51,12 +197,11 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.text.attrs }
 	input.text.attrs = 
 		(	common.attrs
-		&	common-form.attrs
 		&	input.text.attrs.type?
-		&	shared-form.attrs.maxlength? 
-		&	shared-form.attrs.readonly?
-		&	shared-form.attrs.size?
 		&	input.text.attrs.value? 
+		&	shared-form.attrs.single-line-text-edit
+		&	shared-form.attrs.dirname? 
+		&	input.attrs.list?
 		&	(	common.attrs.aria.implicit.textbox
 			|	common.attrs.aria.role.textbox
 			|	common.attrs.aria.role.combobox
@@ -81,12 +226,10 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.password.attrs }
 	input.password.attrs = 
 		(	common.attrs
-		&	common-form.attrs
 		&	input.password.attrs.type
-		&	shared-form.attrs.maxlength? 
-		&	shared-form.attrs.readonly? 
-		&	shared-form.attrs.size?
 		&	input.password.attrs.value? 
+		&	shared-form.attrs.single-line-text-edit
+		&	aria.prop.required?
 		)
 		input.password.attrs.type = 
 			attribute type {
@@ -106,8 +249,10 @@ datatypes w = "http://whattf.org/datatype-draft"
 	input.checkbox.attrs = 
 		(	common.attrs
 		&	common-form.attrs
+		&	input.attrs.checked?
+		&	shared-form.attrs.required?
+		&	aria.prop.required?
 		&	input.checkbox.attrs.type
-		&	input.attrs.checked? 
 		&	input.checkbox.attrs.value? 
 		&	(	common.attrs.aria.implicit.checkbox
 			|	common.attrs.aria.role.checkbox
@@ -135,8 +280,10 @@ datatypes w = "http://whattf.org/datatype-draft"
 	input.radio.attrs = 
 		(	common.attrs
 		&	common-form.attrs
+		&	input.attrs.checked?
+		&	shared-form.attrs.required?
+		&	aria.prop.required?
 		&	input.radio.attrs.type
-		&	input.attrs.checked? 
 		&	input.radio.attrs.value? 
 		&	(	common.attrs.aria.implicit.radio
 			|	common.attrs.aria.role.radio
@@ -195,7 +342,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.submit.attrs }
 	input.submit.attrs = 
 		(	common.attrs
-		&	common-form.attrs
+		&	shared-form.attrs.submit
 		&	input.submit.attrs.type
 		&	input.submit.attrs.value? 
 		&	(	common.attrs.aria.implicit.button
@@ -245,8 +392,12 @@ datatypes w = "http://whattf.org/datatype-draft"
 	input.file.attrs = 
 		(	common.attrs
 		&	common-form.attrs
+		&	input.attrs.multiple?
+		&	shared-form.attrs.required?
+		&	aria.prop.required?
 		&	input.file.attrs.type
 		&	input.file.attrs.accept?
+		&	input.input.attrs.capture?
 		)
 		input.file.attrs.type = 
 			attribute type {
@@ -255,6 +406,10 @@ datatypes w = "http://whattf.org/datatype-draft"
 		input.file.attrs.accept = 
 			attribute accept {
 				form.data.mimetypelist
+			}
+		input.input.attrs.capture =
+			attribute capture {
+				w:string "user" | w:string "environment"
 			}
 
 	input.elem |= input.file.elem
@@ -266,6 +421,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 	input.hidden.attrs = 
 		(	common.attrs
 		&	common-form.attrs
+		&	input.attrs.autocomplete?
 		&	input.hidden.attrs.type
 		&	input.hidden.attrs.value? 
 		)
@@ -286,10 +442,12 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.image.attrs }
 	input.image.attrs = 
 		(	common.attrs
-		&	common-form.attrs
+		&	shared-form.attrs.submit
 		&	input.image.attrs.type
 		&	input.image.attrs.alt 
 		&	input.image.attrs.src? 
+		&	input.image.attrs.height?
+		&	input.image.attrs.width?
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
 			|	common.attrs.aria.role.link
@@ -312,6 +470,14 @@ datatypes w = "http://whattf.org/datatype-draft"
 			attribute src {
 				common.data.uri.non-empty
 			}
+		input.image.attrs.height =
+			attribute height {
+				common.data.integer.non-negative
+			}
+		input.image.attrs.width =
+			attribute width {
+				common.data.integer.non-negative
+			}
 	
 	input.elem |= input.image.elem
 	
@@ -323,8 +489,8 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element textarea { textarea.inner & textarea.attrs }
 	textarea.attrs =
 		(	common.attrs
-		&	common-form.attrs
-		&	shared-form.attrs.readonly?
+		&	shared-form.attrs.text-edit
+		&	shared-form.attrs.dirname? 
 		&	textarea.attrs.rows-and-cols-wf1
 		&	(	common.attrs.aria.implicit.textbox
 			|	common.attrs.aria.role.textbox
@@ -453,7 +619,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element button { button.inner & button.submit.attrs }	
 	button.submit.attrs =
 		(	common.attrs
-		&	common-form.attrs
+		&	shared-form.attrs.submit
 		&	button.submit.attrs.type?
 		&	button.attrs.value?
 		&	(	common.attrs.aria.implicit.button

--- a/schema/html5/web-forms2.rnc
+++ b/schema/html5/web-forms2.rnc
@@ -4,261 +4,19 @@ datatypes w = "http://whattf.org/datatype-draft"
 ##  RELAX NG Schema for HTML 5: Web Forms 2.0 markup                  #
 # #####################################################################
 
-## Shared attributes for form controls
-
-	common-form.attrs &=
-		( common-form.attrs.form? )
-
-	common-form.attrs.form |= 
-		attribute form {
-			common.data.idref
-		}
-
-	shared-form.attrs.formaction =
-		attribute formaction {
-			common.data.uri.non-empty
-		}
-
-	shared-form.attrs.formenctype =
-		attribute formenctype {
-			shared-form.attrs.formenctype.data
-		}
-		shared-form.attrs.formenctype.data = 
-			(	w:string "application/x-www-form-urlencoded" 
-			|	w:string "multipart/form-data"
-			|	w:string "text/plain"
-			)
-
-	shared-form.attrs.formmethod =
-		attribute formmethod {
-			shared-form.attrs.formmethod.data
-		}
-		shared-form.attrs.formmethod.data = 
-			( w:string "get"
-			| w:string "post"
-			| w:string "dialog"
-			)
-
-	shared-form.attrs.formtarget = 
-		attribute formtarget {
-			common.data.browsing-context-or-keyword
-		}
-
-	shared-form.attrs.formnovalidate = 
-		attribute formnovalidate {
-			w:string "formnovalidate" | w:string ""
-		}
-
-	shared-form.attrs.pattern = 
-		attribute pattern {
-			form.data.pattern
-		}
-
-	shared-form.attrs.template = 
-		attribute template {
-			common.data.idref
-		}
-
-	shared-form.attrs.required = 
-		attribute required {
-			w:string "required" | w:string ""
-		}
-
-	shared-form.attrs.placeholder = 
-		attribute placeholder {
-			form.data.stringwithoutlinebreaks
-		}
-
-	shared-form.attrs.dirname = 
-		attribute dirname {
-			form.data.nonemptystring
-		}
-
-	shared-form.attrs.minlength =
-		attribute minlength {
-			common.data.integer.non-negative
-		}
-
-## Shared attributes for <input>
-		
-	shared-input-no-size.attrs =
-		(	input.attrs.autocomplete?
-		&	input.attrs.list?
-		&	shared-form.attrs.maxlength?
-		&	shared-form.attrs.minlength?
-		&	shared-form.attrs.pattern?
-		&	shared-form.attrs.placeholder?
-		&	aria.prop.placeholder?
-		&	shared-form.attrs.readonly?
-		&	shared-form.attrs.required?
-		)
-
-	shared-input-no-list.attrs =
-		(	input.attrs.autocomplete?
-		&	shared-form.attrs.maxlength?
-		&	shared-form.attrs.minlength?
-		&	shared-form.attrs.pattern?
-		&	shared-form.attrs.placeholder?
-		&	aria.prop.placeholder?
-		&	shared-form.attrs.readonly?
-		&	shared-form.attrs.required?
-		&	shared-form.attrs.size?
-		)
-
-	shared-input.attrs =
-		(	shared-input-no-size.attrs
-		&	shared-form.attrs.size?
-		)
-
-	input.attrs.list = 
-		attribute list {
-			common.data.idref
-		}
-	
-	input.attrs.step.float = 
-		attribute step {
-			w:string "any" | common.data.float.positive
-		}
-	
-	input.attrs.step.integer = 
-		attribute step {
-			w:string "any" | common.data.integer.positive 
-		}
-	
-	input.attrs.multiple = 
-		attribute multiple {
-			w:string "multiple" | w:string ""
-		}
-
-## autocomplete
-
-	input.attrs.autocomplete.any =
-		attribute autocomplete {
-			(	w:string "on" | w:string "off"
-			|	common.data.autocomplete.any
-			)
-		}
-
-	input.attrs.autocomplete =
-		attribute autocomplete {
-			string
-		}
-
-## Hidden String: <input type='hidden'>, Extensions
-
-	input.hidden.attrs &=
-		input.attrs.autocomplete?
-
-## Text Field: <input type='text'>, Extensions
-
-	input.text.attrs &=
-		(	input.attrs.autocomplete?
-		&	shared-form.attrs.dirname?
-		&	input.attrs.list?
-		&	shared-form.attrs.pattern?
-		&	shared-form.attrs.required?
-		&	shared-form.attrs.placeholder?
-		&	aria.prop.placeholder?
-		&	shared-form.attrs.minlength?
-		)
-
-## Password Field: <input type='password'>, Extensions
-
-	input.password.attrs &=
-		(	input.attrs.autocomplete?
-		&	input.attrs.list?
-		&	shared-form.attrs.pattern?
-		&	shared-form.attrs.placeholder?
-		&	aria.prop.placeholder?
-		&	shared-form.attrs.required?
-		&	aria.prop.required?
-		&	shared-form.attrs.minlength?
-		)
-
-## Checkbox <input type='checkbox'>, Extensions
-
-	input.checkbox.attrs &=
-		(	shared-input.attrs
-		&	aria.prop.required?
-		)
-
-## Radiobutton: <input type='radio'>, Extensions
-
-	input.radio.attrs &=
-		(	shared-input.attrs
-		&	aria.prop.required?
-		)
-
-## Scripting Hook Button: <input type='button'>, Extensions
-
-	input.button.attrs &=
-		(	shared-input.attrs	)
-
-## Submit Button: <input type='submit'>, Extensions
-
-	input.submit.attrs &=
-		(	shared-input.attrs
-		&	shared-form.attrs.formaction?
-		&	shared-form.attrs.formenctype?
-		&	shared-form.attrs.formmethod?
-		&	shared-form.attrs.formtarget?
-		&	shared-form.attrs.formnovalidate?
-		)
-
-## Reset Button: <input type='reset'>, Extensions
-
-	input.reset.attrs &=
-		(	shared-input.attrs	)
-
-## File Upload: <input type='file'>, Extensions
-
-	input.file.attrs &=
-		(	shared-input.attrs
-		&	input.attrs.multiple?
-		&	aria.prop.required?
-		&	input.input.attrs.capture?
-		)
-		input.input.attrs.capture =
-			attribute capture {
-				w:string "user" | w:string "environment"
-			}
-
-## Image Submit Button: <input type='image'>, Extensions
-
-	input.image.attrs &=
-		(	shared-input.attrs
-		&	shared-form.attrs.formaction?
-		&	shared-form.attrs.formenctype?
-		&	shared-form.attrs.formmethod?
-		&	shared-form.attrs.formtarget?
-		&	shared-form.attrs.formnovalidate?
-		&	input.image.attrs.height?
-		&	input.image.attrs.width?
-		)	
-		input.image.attrs.height =
-			attribute height {
-				common.data.integer.non-negative
-			}
-		input.image.attrs.width =
-			attribute width {
-				common.data.integer.non-negative
-			}
-
 ## Date and Time with No Time Zone Information: <input type='datetime-local'>
 
 	input.datetime-local.elem = 
 		element input { input.datetime-local.attrs }
 	input.datetime-local.attrs = 
 		(	common.attrs
-		&	common-form.attrs
-		&	shared-input.attrs
+		&	shared-form.attrs.date-time
 		&	input.datetime-local.attrs.type
 		&	input.datetime-local.attrs.min?
 		&	aria.prop.valuemin?
 		&	input.datetime-local.attrs.max?
 		&	aria.prop.valuemax?
 		&	input.attrs.step.float?
-		&	aria.prop.required?
 		&	input.datetime-local.attrs.value?
 		)	
 		input.datetime-local.attrs.type = 
@@ -286,14 +44,12 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.date.attrs }
 	input.date.attrs = 
 		(	common.attrs
-		&	common-form.attrs
-		&	shared-input.attrs
+		&	shared-form.attrs.date-time
 		&	input.date.attrs.type
 		&	input.date.attrs.min?
 		&	aria.prop.valuemin?
 		&	input.date.attrs.max?
 		&	aria.prop.valuemax?
-		&	aria.prop.required?
 		&	input.attrs.step.integer?
 		&	input.date.attrs.value?
 		)	
@@ -322,14 +78,12 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.month.attrs }
 	input.month.attrs = 
 		(	common.attrs
-		&	common-form.attrs
-		&	shared-input.attrs
+		&	shared-form.attrs.date-time
 		&	input.month.attrs.type
 		&	input.month.attrs.min?
 		&	aria.prop.valuemin?
 		&	input.month.attrs.max?
 		&	aria.prop.valuemax?
-		&	aria.prop.required?
 		&	input.attrs.step.integer?
 		&	input.month.attrs.value?
 		)	
@@ -358,14 +112,12 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.time.attrs }
 	input.time.attrs = 
 		(	common.attrs
-		&	common-form.attrs
-		&	shared-input.attrs
+		&	shared-form.attrs.date-time
 		&	input.time.attrs.type
 		&	input.time.attrs.min?
 		&	aria.prop.valuemin?
 		&	input.time.attrs.max?
 		&	aria.prop.valuemax?
-		&	aria.prop.required?
 		&	input.attrs.step.float?
 		&	input.time.attrs.value?
 		)	
@@ -394,14 +146,12 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.week.attrs }
 	input.week.attrs = 
 		(	common.attrs
-		&	common-form.attrs
-		&	shared-input.attrs
+		&	shared-form.attrs.date-time
 		&	input.week.attrs.type
 		&	input.week.attrs.min?
 		&	aria.prop.valuemin?
 		&	input.week.attrs.max?
 		&	aria.prop.valuemax?
-		&	aria.prop.required?
 		&	input.attrs.step.integer?
 		&	input.week.attrs.value?
 		)	
@@ -431,7 +181,12 @@ datatypes w = "http://whattf.org/datatype-draft"
 	input.number.attrs = 
 		(	common.attrs
 		&	common-form.attrs
-		&	shared-input-no-size.attrs
+		&	input.attrs.autocomplete?
+		&	input.attrs.list?
+		&	shared-form.attrs.placeholder?
+		&	aria.prop.placeholder?
+		&	shared-form.attrs.required?
+		&	shared-form.attrs.readonly?
 		&	input.number.attrs.type
 		&	input.number.attrs.min?
 		&	input.number.attrs.max?
@@ -467,7 +222,8 @@ datatypes w = "http://whattf.org/datatype-draft"
 	input.range.attrs = 
 		(	common.attrs
 		&	common-form.attrs
-		&	shared-input-no-size.attrs
+		&	input.attrs.autocomplete?
+		&	input.attrs.list?
 		&	input.range.attrs.type
 		&	input.range.attrs.min?
 		&	input.range.attrs.max?
@@ -502,14 +258,13 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.email.attrs }	
 	input.email.attrs = 
 		(	common.attrs
-		&	common-form.attrs
-		&	shared-input-no-list.attrs
 		&	input.email.attrs.type
 		&	(	(	input.attrs.multiple
 				&	input.email.attrs.value.multiple?
 				)
 			|	input.email.attrs.value.single?
 			)?
+		&	shared-form.attrs.single-line-text-edit
 		&	(
 				(	common.attrs.aria.implicit.textbox
 				|	common.attrs.aria.role.textbox
@@ -542,10 +297,9 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.url.attrs }
 	input.url.attrs = 
 		(	common.attrs
-		&	common-form.attrs
-		&	shared-input-no-list.attrs
 		&	input.url.attrs.type
-		&	input.url.attrs.value?
+		&	input.url.attrs.value? 
+		&	shared-form.attrs.single-line-text-edit
 		&	(
 				(	common.attrs.aria.implicit.textbox
 				|	common.attrs.aria.role.textbox
@@ -574,11 +328,11 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.search.attrs }
 	input.search.attrs = 
 		(	common.attrs
-		&	common-form.attrs
-		&	shared-input.attrs
 		&	input.search.attrs.type
-		&	input.search.attrs.value?
-		&	shared-form.attrs.dirname?
+		&	input.search.attrs.value? 
+		&	shared-form.attrs.single-line-text-edit
+		&	shared-form.attrs.dirname? 
+		&	input.attrs.list?
 		&	(	common.attrs.aria.implicit.searchbox
 			|	common.attrs.aria.role.searchbox
 			)?
@@ -600,10 +354,9 @@ datatypes w = "http://whattf.org/datatype-draft"
 		element input { input.tel.attrs }	
 	input.tel.attrs = 
 		(	common.attrs
-		&	common-form.attrs
-		&	shared-input-no-list.attrs
 		&	input.tel.attrs.type
-		&	input.tel.attrs.value?
+		&	input.tel.attrs.value? 
+		&	shared-form.attrs.single-line-text-edit
 		&	(
 				(	common.attrs.aria.implicit.textbox
 				|	common.attrs.aria.role.textbox
@@ -633,9 +386,10 @@ datatypes w = "http://whattf.org/datatype-draft"
 	input.color.attrs = 
 		(	common.attrs
 		&	common-form.attrs
+		&	input.attrs.autocomplete?
+		&	input.attrs.list?
 		&	input.color.attrs.type
 		&	input.color.attrs.value?
-		&	shared-input.attrs
 		)	
 		input.color.attrs.type = 
 			attribute type {
@@ -677,12 +431,8 @@ datatypes w = "http://whattf.org/datatype-draft"
 	textarea.attrs.rows-and-cols-wf1 |= 
 		empty
 	textarea.attrs &=
-		(	shared-form.attrs.maxlength?
-		&	shared-form.attrs.minlength?
-		&	shared-form.attrs.required? 
-		&	textarea.attrs.placeholder?
+		(	textarea.attrs.placeholder?
 		&	aria.prop.placeholder?
-		&	shared-form.attrs.dirname?
 		&	textarea.attrs.rows?
 		&	(	(	textarea.attrs.wrap.hard 
 				&	textarea.attrs.cols
@@ -722,16 +472,6 @@ datatypes w = "http://whattf.org/datatype-draft"
 		)
 
 	common.elem.phrasing |= datalist.elem
-
-## Complex Submit Button: <button type='submit'>, extensions
-
-	button.submit.attrs &=
-		(	shared-form.attrs.formaction? 
-		&	shared-form.attrs.formenctype? 
-		&	shared-form.attrs.formmethod? 
-		&	shared-form.attrs.formtarget? 
-		&	shared-form.attrs.formnovalidate? 
-		)
 	
 
 ## Form: <form>, extensions

--- a/src/nu/validator/checker/schematronequiv/Assertions.java
+++ b/src/nu/validator/checker/schematronequiv/Assertions.java
@@ -138,42 +138,6 @@ public class Assertions extends Checker {
         return "";
     }
 
-    private static final Map<String, String[]> INPUT_ATTRIBUTES = new HashMap<>();
-
-    static {
-        INPUT_ATTRIBUTES.put("autocomplete",
-                new String[] { "hidden", "text", "search", "url", "tel", "email",
-                        "password", "date", "month", "week", "time",
-                        "datetime-local", "number", "range", "color" });
-        INPUT_ATTRIBUTES.put("list",
-                new String[] { "text", "search", "url", "tel", "email",
-                        "date", "month", "week", "time",
-                        "datetime-local", "number", "range", "color" });
-        INPUT_ATTRIBUTES.put("maxlength", new String[] { "text", "search",
-                "url", "tel", "email", "password" });
-        INPUT_ATTRIBUTES.put("minlength", new String[] { "text", "search",
-                "url", "tel", "email", "password" });
-        INPUT_ATTRIBUTES.put("pattern", new String[] { "text", "search", "url",
-                "tel", "email", "password" });
-        INPUT_ATTRIBUTES.put("placeholder", new String[] { "text", "search",
-                "url", "tel", "email", "password", "number" });
-        INPUT_ATTRIBUTES.put("readonly",
-                new String[] { "text", "search", "url", "tel", "email",
-                        "password", "date", "month", "week", "time",
-                        "datetime-local", "number" });
-        INPUT_ATTRIBUTES.put("required",
-                new String[] { "text", "search", "url", "tel", "email",
-                        "password", "date", "month", "week", "time",
-                        "datetime-local", "number", "checkbox", "radio",
-                        "file" });
-        INPUT_ATTRIBUTES.put("size", new String[] { "text", "search", "url",
-                "tel", "email", "password" });
-
-        for (String[] allowedTypes: INPUT_ATTRIBUTES.values()) {
-            Arrays.sort(allowedTypes);
-        }
-    }
-
     private static final Map<String, String> OBSOLETE_ELEMENTS = new HashMap<>();
 
     static {
@@ -1971,18 +1935,6 @@ public class Assertions extends Checker {
                         if (Arrays.binarySearch(elementNames, localName) >= 0) {
                             errObsoleteAttribute(attLocal, localName,
                                     " Use CSS instead.");
-                        }
-                    } else if (INPUT_ATTRIBUTES.containsKey(attLocal)
-                            && "input" == localName) {
-                        String[] allowedTypes = INPUT_ATTRIBUTES.get(attLocal);
-                        inputTypeVal = inputTypeVal == null ? "text"
-                                : inputTypeVal;
-                        if (Arrays.binarySearch(allowedTypes,
-                                inputTypeVal) < 0) {
-                            err("Attribute \u201c" + attLocal
-                                    + "\u201d is only allowed when the input"
-                                    + " type is " + renderTypeList(allowedTypes)
-                                    + ".");
                         }
                     } else if ("autofocus" == attLocal) {
                         if (hasAutofocus) {


### PR DESCRIPTION
This PR slightly reworks web-forms.rnc & web-forms2.rnc, correcting list of possible form attributes for each input type. It made usage of INPUT_ATTRIBUTES in Assertions.java obsolete and was removed. Now any invalid attribute in input element shows error like that:
![image](https://user-images.githubusercontent.com/100634371/198044126-dd7cb4ed-a5b2-4239-bd6a-c46887851764.png)

I have also cleaned up both rnc files a little bit, moving all attributes to web-forms.rnc & connecting input types which were present in both files.

I think it would be better to make web-forms-input.rnc and move all rules regarding input types in there. In web-forms2.rnc there would be just few rules, so we could be move them to web-forms.rnc and delete the file.
We could also change naming of types regarding form attributes, because currently they are under:
1. shared-form.attrs
2. common-form.attrs
3. input.attrs

What do you think?