### PR TITLE
media attribute in meta element

### DIFF
--- a/schema/html5/meta.rnc
+++ b/schema/html5/meta.rnc
@@ -283,6 +283,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	common.attrs.microdata.itemscope?
 		&	common.attrs.microdata.itemtype?
 		&	common.attrs.microdata.itemid?
+		&	shared-hyperlink.attrs.media?
 		)
 		meta.name.attrs.name =
 			attribute name {

--- a/src/nu/validator/checker/schematronequiv/Assertions.java
+++ b/src/nu/validator/checker/schematronequiv/Assertions.java
@@ -2986,6 +2986,14 @@ public class Assertions extends Checker {
                     }
                     hasContentTypePragma = true;
                 }
+                if (atts.getIndex("", "media") > -1 &&
+                        (atts.getIndex("", "name") <= -1
+                        || !atts.getValue("", "name").equalsIgnoreCase("theme-color"))) {
+                    err("A \u201Cmeta\u201D element with a"
+                                + " \u201Cmedia\u201D attribute must have a"
+                                + " \u201Cname\u201D attribute that contains the"
+                                + " value \u201Ctheme-color\u201D.");
+                }
             }
             if ("link" == localName) {
                 boolean hasRel = false;


### PR DESCRIPTION
Adds [media](https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-media) attribute to meta element, but allows it only when name is `theme-color`.

Fixed #1166 
Fixes #1424 