### PR TITLE
hidden=until-found

### DIFF
--- a/schema/html5/applications.rnc
+++ b/schema/html5/applications.rnc
@@ -32,7 +32,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 
 	common.attrs.hidden =
 		attribute hidden {
-			w:string "hidden" | w:string ""
+			w:string "hidden" | w:string "until-found" | w:string ""
 		}
 
 ## Global attributes applicable on elements with editable content


### PR DESCRIPTION
Adds "until-found" value to hidden attribute, [present in WHATWG spec](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute). I didn't find any restrictions, so just rnc was updated. Event onbeforematch was added together with other events in #1454 

Fixes #1346 