### PR TITLE
whitespace not allowed as autocomplete value

### DIFF
--- a/src/nu/validator/datatype/AbstractAutocompleteDetails.java
+++ b/src/nu/validator/datatype/AbstractAutocompleteDetails.java
@@ -106,14 +106,15 @@ abstract class AbstractAutocompleteDetails extends AbstractDatatype {
 
     @Override
     public void checkValid(CharSequence literal) throws DatatypeException {
-        if (literal.length() == 0) {
+        String trimmed = trimWhitespace(literal.toString());
+        if (trimmed.length() == 0) {
             throw newDatatypeException("Must not be empty.");
         }
         StringBuilder builder = new StringBuilder();
         ArrayList<String> detailTokens = new ArrayList<>();
-        int len = literal.length();
+        int len = trimmed.length();
         for (int i = 0; i < len; i++) {
-            char c = literal.charAt(i);
+            char c = trimmed.charAt(i);
             if (isWhitespace(c) && builder.length() > 0) {
                 detailTokens.add(builder.toString());
                 builder.setLength(0);

--- a/src/nu/validator/datatype/AbstractDatatype.java
+++ b/src/nu/validator/datatype/AbstractDatatype.java
@@ -152,6 +152,20 @@ public abstract class AbstractDatatype implements Datatype {
     public boolean isContextDependent() {
         return false;
     }
+    
+    protected final String trimWhitespace(String s) {
+        int len = s.length();
+        int st = 0;
+        char[] val = s.toCharArray();
+    
+        while ((st < len) && (isWhitespace(val[st]))) {
+            st++;
+        }
+        while ((st < len) && (isWhitespace(val[len - 1]))) {
+            len--;
+        }
+        return ((st > 0) || (len < s.length())) ? s.substring(st, len) : s;
+    }
 
     /**
      * Checks if a UTF-16 code unit represents a whitespace character (U+0020, 


### PR DESCRIPTION
Trims ASCII whitespace while calculating size of autocomplete value, so whitespace like `    ` is counted as 0 and following error is thrown: `Bad value '    ' for attribute autocomplete on element input: Must not be empty.`

Fixes #1192 