### PR TITLE
blocking="render"

### DIFF
--- a/schema/html5/common.rnc
+++ b/schema/html5/common.rnc
@@ -212,7 +212,7 @@ common.attrs.other =
 
 	common.attrs.blocking = 
 		attribute blocking {
-			w:string "render" | w:string ""
+			list { w:string "render" }
 		}
 
 	common.attrs.nonce =

--- a/schema/html5/common.rnc
+++ b/schema/html5/common.rnc
@@ -210,6 +210,11 @@ common.attrs.other =
 			w:string "autofocus" | w:string ""
 		}
 
+	common.attrs.blocking = 
+		attribute blocking {
+			w:string "render" | w:string ""
+		}
+
 	common.attrs.nonce =
 		attribute nonce {
 			string

--- a/schema/html5/core-scripting.rnc
+++ b/schema/html5/core-scripting.rnc
@@ -33,6 +33,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	script.attrs.language? # restricted in Schematron
 		&	script.attrs.integrity?
 		&	embedded.content.attrs.crossorigin?
+		&	common.attrs.blocking?
 		&	referrerpolicy?
 		)
 		script.attrs.src =

--- a/schema/html5/meta.rnc
+++ b/schema/html5/meta.rnc
@@ -166,6 +166,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	link.attrs.imagesizes?
 		#	link.attrs.title included in common.attrs
 		&	embedded.content.attrs.crossorigin?
+		&	common.attrs.blocking?
 		&	common.attrs.aria.role.link?
 		)
 		link.attrs.href =
@@ -253,6 +254,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		(	common.attrs
 		&	style.attrs.type?
 		&	style.attrs.media?
+		&	common.attrs.blocking?
 		#	style.attrs.title included in common.attrs
 		)
 		style.attrs.type =

--- a/src/nu/validator/checker/schematronequiv/Assertions.java
+++ b/src/nu/validator/checker/schematronequiv/Assertions.java
@@ -3166,6 +3166,17 @@ public class Assertions extends Checker {
                             + " \u201Cprerender\u201D, or"
                             + " \u201Cstylesheet\u201D.");
                 }
+                if (atts.getIndex("", "blocking") > -1
+                        && atts.getValue("", "blocking").equalsIgnoreCase("render")
+                        && (atts.getIndex("", "rel") == -1
+                        || !(relList.contains("modulepreload")
+                            || relList.contains("preload")
+                            || relList.contains("stylesheet")))) {
+                    err("A \u201Clink\u201D element with a"
+                                + " \u201Cblocking\u201D attribute containing value \u201Crender\u201D,"
+                                + " must have a \u201Crel\u201D attribute with value \u201Cmodulepreload\u201D," +
+                                " \u201Cpreload\u201D or \u201Cstylesheet\u201D.");
+                }
             }
 
             // microdata

--- a/src/nu/validator/checker/schematronequiv/Assertions.java
+++ b/src/nu/validator/checker/schematronequiv/Assertions.java
@@ -3167,13 +3167,12 @@ public class Assertions extends Checker {
                             + " \u201Cstylesheet\u201D.");
                 }
                 if (atts.getIndex("", "blocking") > -1
-                        && atts.getValue("", "blocking").equalsIgnoreCase("render")
                         && (atts.getIndex("", "rel") == -1
                         || !(relList.contains("modulepreload")
                             || relList.contains("preload")
                             || relList.contains("stylesheet")))) {
                     err("A \u201Clink\u201D element with a"
-                                + " \u201Cblocking\u201D attribute containing value \u201Crender\u201D,"
+                                + " \u201Cblocking\u201D attribute,"
                                 + " must have a \u201Crel\u201D attribute with value \u201Cmodulepreload\u201D," +
                                 " \u201Cpreload\u201D or \u201Cstylesheet\u201D.");
                 }

--- a/src/nu/validator/checker/schematronequiv/Assertions.java
+++ b/src/nu/validator/checker/schematronequiv/Assertions.java
@@ -3172,9 +3172,11 @@ public class Assertions extends Checker {
                             || relList.contains("preload")
                             || relList.contains("stylesheet")))) {
                     err("A \u201Clink\u201D element with a"
-                                + " \u201Cblocking\u201D attribute,"
-                                + " must have a \u201Crel\u201D attribute with value \u201Cmodulepreload\u201D," +
-                                " \u201Cpreload\u201D or \u201Cstylesheet\u201D.");
+                                + " \u201Cblocking\u201D attribute must have a"
+                                + " \u201Crel\u201D attribute whose value is"
+                                + " \u201Cmodulepreload\u201D,"
+                                + " \u201Cpreload\u201D, or"
+                                + " \u201Cstylesheet\u201D.");
                 }
             }
 


### PR DESCRIPTION
Adds implementation for [blocking](https://github.com/whatwg/html/pull/7474/files) attribute to `link`, `style` & `script`. When used inside `link` element, it requires `rel` attribute to be either `modulepreload`, `preload`, or `stylesheet`.

Fixes #1315 