### PR TITLE
Allow paragraphs in hgroup

### DIFF
--- a/schema/html5/sectional.rnc
+++ b/schema/html5/sectional.rnc
@@ -131,7 +131,7 @@
 			)
 			&	p.elem*
 			&	common.elem.script-supporting*
-		)+
+		)
 
 	common.elem.flow |= hgroup.elem
 

--- a/schema/html5/sectional.rnc
+++ b/schema/html5/sectional.rnc
@@ -129,6 +129,7 @@
 			|	h5.elem
 			|	h6.elem
 			)
+			&	p.elem*
 			&	common.elem.script-supporting*
 		)+
 


### PR DESCRIPTION
Allows zero or more `p` elements in `hgroup`.

Fixes #1397 