### PR TITLE
Fix check for input type=hidden using any aria

### DIFF
--- a/src/nu/validator/checker/schematronequiv/Assertions.java
+++ b/src/nu/validator/checker/schematronequiv/Assertions.java
@@ -2036,10 +2036,9 @@ public class Assertions extends Checker {
                             + " attribute of the \u201cinput\u201d element is"
                             + " not allowed.");
                 }
-                if (atts.getIndex("", "hidden") > -1
-                        && ((atts.getIndex("", "aria-hidden") > -1
-                                && !"".equals(atts.getValue("", "aria-hidden")))
-                                || hasAriaAttributesOtherThanAriaHidden)) {
+                if (atts.getIndex("", "type") > -1
+                        && "hidden".equals(atts.getValue("", "type"))
+                        && hasAriaAttributesOtherThanAriaHidden) {
                     err("An \u201cinput\u201d element with a \u201ctype\u201d"
                             + " attribute whose value is \u201chidden\u201d"
                             + " must not have any \u201Caria-*\u201D"


### PR DESCRIPTION
This is correction for commit [84bde80](https://github.com/validator/validator/commit/84bde80) fixing #1106. Now assertion checks type=hidden instead of global attribute hidden. I have also removed 2 lines regarding aria-hidden, because `<input type=hidden aria-hidden="true"` would print:

![image](https://user-images.githubusercontent.com/100634371/198851006-be69e0e2-58e0-42da-ac33-aa62e3e3e761.png)
