### PR TITLE
Error on nested "a" in SVG

### DIFF
--- a/src/nu/validator/checker/schematronequiv/Assertions.java
+++ b/src/nu/validator/checker/schematronequiv/Assertions.java
@@ -1734,6 +1734,16 @@ public class Assertions extends Checker {
             warn("Element \u201Cmath\u201D does not need a"
                     + " \u201Crole\u201D attribute.");
         }
+        if ("http://www.w3.org/2000/svg" == uri) {
+            if ("a" == localName) {
+                for(int i = 0;i < currentPtr;i++) {
+                    String ancestorName = stack[currentPtr - i].getName();
+                    if("a".equals(ancestorName)) {
+                        err("The element \u201Ca\u201D must not appear as a descendant of an element \u201Ca\u201D.");
+                    }
+                }
+            }
+        }
         if ("http://www.w3.org/1999/xhtml" == uri) {
             boolean controls = false;
             boolean hidden = false;
@@ -3605,7 +3615,7 @@ public class Assertions extends Checker {
                     + " \u201chttp://n.validator.nu/custom-elements/\u201d"
                     + " not allowed.");
         } else {
-            StackNode child = new StackNode(ancestorMask, null, role,
+            StackNode child = new StackNode(ancestorMask, localName, role,
                     activeDescendant, forAttr);
             if (activeDescendant != null) {
                 openActiveDescendants.put(child,

--- a/src/nu/validator/checker/schematronequiv/Assertions.java
+++ b/src/nu/validator/checker/schematronequiv/Assertions.java
@@ -1734,13 +1734,12 @@ public class Assertions extends Checker {
             warn("Element \u201Cmath\u201D does not need a"
                     + " \u201Crole\u201D attribute.");
         }
-        if ("http://www.w3.org/2000/svg" == uri) {
-            if ("a" == localName) {
-                for(int i = 0;i < currentPtr;i++) {
-                    String ancestorName = stack[currentPtr - i].getName();
-                    if("a".equals(ancestorName)) {
-                        err("The element \u201Ca\u201D must not appear as a descendant of an element \u201Ca\u201D.");
-                    }
+        if ("http://www.w3.org/2000/svg" == uri
+                && "a".equals(localName)) {
+            for(int i = 0;i < currentPtr;i++) {
+                String ancestorName = stack[currentPtr - i].getName();
+                if("a".equals(ancestorName)) {
+                    err("The element \u201Ca\u201D must not appear as a descendant of an element \u201Ca\u201D.");
                 }
             }
         }


### PR DESCRIPTION
Prints error when "a" element inside SVG has "a" descendant in that SVG or anywhere outside of it. Setting "name" variable in StackNode class of non html elements is potentially a breaking change, but I think everything will be fine.

Fixes #1081 