### PR TITLE
autocomplete requires 1 autofill field

### DIFF
--- a/src/nu/validator/datatype/AbstractAutocompleteDetails.java
+++ b/src/nu/validator/datatype/AbstractAutocompleteDetails.java
@@ -106,15 +106,11 @@ abstract class AbstractAutocompleteDetails extends AbstractDatatype {
 
     @Override
     public void checkValid(CharSequence literal) throws DatatypeException {
-        String trimmed = trimWhitespace(literal.toString());
-        if (trimmed.length() == 0) {
-            throw newDatatypeException("Must not be empty.");
-        }
         StringBuilder builder = new StringBuilder();
         ArrayList<String> detailTokens = new ArrayList<>();
-        int len = trimmed.length();
+        int len = literal.length();
         for (int i = 0; i < len; i++) {
-            char c = trimmed.charAt(i);
+            char c = literal.charAt(i);
             if (isWhitespace(c) && builder.length() > 0) {
                 detailTokens.add(builder.toString());
                 builder.setLength(0);
@@ -125,55 +121,25 @@ abstract class AbstractAutocompleteDetails extends AbstractDatatype {
         if (builder.length() > 0) {
             detailTokens.add(builder.toString());
         }
-        if (detailTokens.size() > 0) {
-            checkTokens(detailTokens);
-        }
+        checkTokens(detailTokens);
     }
 
     private void checkTokens(ArrayList<String> detailTokens)
             throws DatatypeException {
         boolean isContactDetails = false;
-        String contactType = "";
-        String firstRemainingToken = "";
-        if (detailTokens.size() < 1) {
-            return;
-        }
-        if (CONTACT_TYPES.contains(detailTokens.get(0))) {
-            isContactDetails = true;
-            contactType = detailTokens.get(0);
-            detailTokens.remove(0);
-        }
-        if (detailTokens.size() > 0
+        if (!detailTokens.isEmpty()
                 && detailTokens.get(0).startsWith("section-")) {
-            if (isContactDetails) {
-                throw newDatatypeException(
-                        "A \u201csection-*\u201d indicator is not allowed"
-                                + " when the first token in a list"
-                                + " of autofill detail tokens is" + " \u201c"
-                                + contactType + "\u201d.");
-            }
             detailTokens.remove(0);
         }
-        if (detailTokens.size() < 1) {
-            return;
-        }
-        firstRemainingToken = detailTokens.get(0);
-        if (firstRemainingToken.equals("shipping")
-                || firstRemainingToken.equals("billing")) {
-            if (isContactDetails) {
-                throw newDatatypeException(
-                        "The token \u201c" + firstRemainingToken + "\u201d is"
-                                + " not allowed when the first token in a list"
-                                + " of autofill detail tokens is" + " \u201c"
-                                + contactType + "\u201d.");
-            }
+        if (!detailTokens.isEmpty()
+                && (detailTokens.get(0).equals("shipping")
+                || detailTokens.get(0).equals("billing"))) {
             detailTokens.remove(0);
         }
-        if (detailTokens.size() > 0
+        if (!detailTokens.isEmpty()
                 && CONTACT_TYPES.contains(detailTokens.get(0))) {
-            isContactDetails = true;
-            contactType = detailTokens.get(0);
             detailTokens.remove(0);
+            isContactDetails = true;
         }
         for (String token : detailTokens) {
             if (CONTACT_TYPES.contains(token)) {
@@ -210,6 +176,8 @@ abstract class AbstractAutocompleteDetails extends AbstractDatatype {
         if (detailTokens.size() > 1) {
             throw newDatatypeException("A list of autofill details tokens must"
                     + " not contain more than one autofill field name.");
+        } else if (detailTokens.isEmpty()) {
+            throw newDatatypeException("A list must contain autofill field name.");
         }
     }
 

--- a/src/nu/validator/datatype/AbstractDatatype.java
+++ b/src/nu/validator/datatype/AbstractDatatype.java
@@ -153,19 +153,6 @@ public abstract class AbstractDatatype implements Datatype {
         return false;
     }
 
-    protected final String trimWhitespace(String s) {
-        int len = s.length();
-        int st = 0;
-        char[] val = s.toCharArray();
-        while ((st < len) && (isWhitespace(val[st]))) {
-            st++;
-        }
-        while ((st < len) && (isWhitespace(val[len - 1]))) {
-            len--;
-        }
-        return ((st > 0) || (len < s.length())) ? s.substring(st, len) : s;
-    }
-
     /**
      * Checks if a UTF-16 code unit represents a whitespace character (U+0020, 
      * U+0009, U+000C, U+000D or U+000A).


### PR DESCRIPTION
This PR improves autocomplete list checker, by making sure that always 1 autofill field is present. Following values are now marked as invalid:
```
<input autocomplete="section-red">
<input autocomplete="billing">
<input autocomplete="mobile">
<input autocomplete="mobile mobile">
```
Algorithm follows [Autofill detail tokens](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) algorithm, except for 4th step which requires webauthn token. I will add it in a separate PR.
