### PR TITLE
Math functions in sizes attribute

### DIFF
--- a/src/nu/validator/datatype/SourceSizeList.java
+++ b/src/nu/validator/datatype/SourceSizeList.java
@@ -64,11 +64,11 @@ public class SourceSizeList extends AbstractDatatype {
         }
         VALID_UNITS.setLength(VALID_UNITS.length() - 1);
     }
-    
+
     private static final Set<String> FUNCTION_NAMES = new LinkedHashSet<>();
-    
+
     private static final StringBuilder VALID_FUNCTION_NAMES = new StringBuilder();
-    
+
     static {
         /* Basic Arithmetic */
         FUNCTION_NAMES.add("calc");
@@ -93,9 +93,10 @@ public class SourceSizeList extends AbstractDatatype {
         /* Sign-Related Functions */
         FUNCTION_NAMES.add("abs");
         FUNCTION_NAMES.add("sign");
-    
+
         for (CharSequence name : FUNCTION_NAMES) {
-            VALID_FUNCTION_NAMES.append(" \u201c").append(name).append("\u201d,");
+            VALID_FUNCTION_NAMES.append(" \u201c").append(name).append(
+                    "\u201d,");
         }
         VALID_FUNCTION_NAMES.setLength(VALID_FUNCTION_NAMES.length() - 1);
     }
@@ -212,25 +213,27 @@ public class SourceSizeList extends AbstractDatatype {
                 unMatchedParenCount++;
             }
         }
-        
-        String functionName = extractFunctionNameFromTail(sb.subSequence(0, firstParenPosition)).toString();
+
+        String functionName = extractFunctionNameFromTail(
+                sb.subSequence(0, firstParenPosition)).toString();
         int nameStartPosition = firstParenPosition - functionName.length();
-        
+
         if (functionName.isEmpty()) {
             errNotFunctionName("", extract);
         } else if (!isLast && nameStartPosition == 0) {
             errNoMediaCondition(sb, extract);
-        } else if (nameStartPosition != 0 && !isWhitespace(sb.charAt(nameStartPosition - 1))) {
+        } else if (nameStartPosition != 0
+                && !isWhitespace(sb.charAt(nameStartPosition - 1))) {
             errNoWhitespaceBeforeFunction(extract);
         } else if (!FUNCTION_NAMES.contains(toAsciiLowerCase(functionName))) {
             errNotFunctionName(functionName, extract);
         }
     }
-    
+
     private CharSequence extractFunctionNameFromTail(CharSequence sequence) {
-        for(int i = sequence.length() - 1;i >= 0;i --) {
+        for (int i = sequence.length() - 1; i >= 0; i--) {
             char c = sequence.charAt(i);
-            if(isWhitespace(c) || c == ')') {
+            if (isWhitespace(c) || c == ')') {
                 return sequence.subSequence(i + 1, sequence.length());
             }
         }
@@ -403,7 +406,8 @@ public class SourceSizeList extends AbstractDatatype {
 
     private void errNotFunctionName(CharSequence name, CharSequence extract)
             throws DatatypeException {
-        String msg = "Expected function (one of" + VALID_FUNCTION_NAMES + ") but found ";
+        String msg = "Expected function (one of" + VALID_FUNCTION_NAMES
+                + ") but found ";
         if ("".equals(name)) {
             msg += "no name";
         } else {
@@ -412,13 +416,13 @@ public class SourceSizeList extends AbstractDatatype {
         msg += " at " + clip(extract) + ".";
         err(msg);
     }
-    
+
     private void errNoWhitespaceBeforeFunction(CharSequence extract)
             throws DatatypeException {
         err("There must be a whitespace between media query and a function at "
-                    + clip(extract) + ".");
+                + clip(extract) + ".");
     }
-    
+
     private void errMismatchedParens(CharSequence cs, CharSequence extract)
             throws DatatypeException {
         err("Mismatched parentheses in " + clip(extract) + ".");


### PR DESCRIPTION
Adds more [math functions](https://drafts.csswg.org/css-values/#math) than just `calc` to attribute `sizes` in `img` element. I skipped `round`, `mod` and `rem`, which are not supported by any browser.

Fixes #803 