### PR TITLE
Adjust Eclipse classpath to updated dependencies.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -9,17 +9,17 @@
 			<attribute name="javadoc_location" value="http://logging.apache.org/log4j/1.2/apidocs/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="dependencies/commons-fileupload-1.3.1.jar">
+	<classpathentry kind="lib" path="dependencies/commons-fileupload-1.4.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="http://commons.apache.org/proper/commons-fileupload/apidocs/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="dependencies/httpcore-4.4.9.jar">
+	<classpathentry kind="lib" path="dependencies/httpcore-4.4.14.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="dependencies/httpclient-4.5.9.jar">
+	<classpathentry kind="lib" path="dependencies/httpclient-4.5.13.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/"/>
 		</attributes>
@@ -39,7 +39,7 @@
 			<attribute name="javadoc_location" value="http://commons.apache.org/proper/commons-logging/javadocs/api-release/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="dependencies/icu4j-58.2.jar">
+	<classpathentry kind="lib" path="dependencies/icu4j-70.1.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="http://icu-project.org/apiref/icu4j/"/>
 		</attributes>
@@ -50,27 +50,27 @@
 			<attribute name="javadoc_location" value="http://docs.oracle.com/javaee/7/api/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="dependencies/jetty-server-9.4.43.v20210629.jar">
+	<classpathentry kind="lib" path="dependencies/jetty-server-9.4.44.v20210927.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="https://www.eclipse.org/jetty/javadoc/jetty-9/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="dependencies/jetty-servlet-9.4.43.v20210629.jar">
+	<classpathentry kind="lib" path="dependencies/jetty-servlet-9.4.44.v20210927.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="https://www.eclipse.org/jetty/javadoc/jetty-9/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="dependencies/jetty-servlets-9.4.43.v20210629.jar">
+	<classpathentry kind="lib" path="dependencies/jetty-servlets-9.4.44.v20210927.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="https://www.eclipse.org/jetty/javadoc/jetty-9/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="dependencies/jetty-util-9.4.43.v20210629.jar">
+	<classpathentry kind="lib" path="dependencies/jetty-util-9.4.44.v20210927.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="https://www.eclipse.org/jetty/javadoc/jetty-9/"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="dependencies/jetty-util-ajax-9.4.43.v20210629.jar">
+	<classpathentry kind="lib" path="dependencies/jetty-util-ajax-9.4.44.v20210927.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="https://www.eclipse.org/jetty/javadoc/jetty-9/"/>
 		</attributes>


### PR DESCRIPTION
The checked-in Eclipse .classpath setting seems to be out-of-date. The dependencies have been updated. The .classpath should be adjusted.