### PR TITLE
Add `fetchpriority` attribute

### DIFF
--- a/schema/html5/common.rnc
+++ b/schema/html5/common.rnc
@@ -216,6 +216,11 @@ common.attrs.other =
 			list { w:string "render" }
 		}
 
+	common.attrs.fetchpriority =
+		attribute fetchpriority {
+			w:string "high" | w:string "low" | w:string "auto"
+		}
+
 	common.attrs.nonce =
 		attribute nonce {
 			string

--- a/schema/html5/core-scripting.rnc
+++ b/schema/html5/core-scripting.rnc
@@ -34,6 +34,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	script.attrs.integrity?
 		&	embedded.content.attrs.crossorigin?
 		&	common.attrs.blocking?
+		&	common.attrs.fetchpriority?
 		&	referrerpolicy?
 		)
 		script.attrs.src =

--- a/schema/html5/embed.rnc
+++ b/schema/html5/embed.rnc
@@ -22,6 +22,7 @@ namespace local = ""
 		&	img.attrs.ismap?
 		&	img.attrs.decoding?
 		&	img.attrs.loading?
+		&	common.attrs.fetchpriority?
 		&	img.attrs.border? # obsolete
 		&	referrerpolicy?
 		&	embedded.content.attrs.crossorigin?

--- a/schema/html5/meta.rnc
+++ b/schema/html5/meta.rnc
@@ -164,6 +164,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	link.attrs.workertype?
 		&	link.attrs.imagesrcset?
 		&	link.attrs.imagesizes?
+		&	common.attrs.fetchpriority?
 		#	link.attrs.title included in common.attrs
 		&	embedded.content.attrs.crossorigin?
 		&	common.attrs.blocking?

--- a/src/nu/validator/checker/schematronequiv/Assertions.java
+++ b/src/nu/validator/checker/schematronequiv/Assertions.java
@@ -678,6 +678,13 @@ public class Assertions extends Checker {
         ATTRIBUTES_WITH_IMPLICIT_STATE_OR_PROPERTY.add("required");
         ATTRIBUTES_WITH_IMPLICIT_STATE_OR_PROPERTY.add("rowspan");
     }
+    
+    /**
+     * Names of link types that are considered as "External Resource" according to https://html.spec.whatwg.org/multipage/links.html#linkTypes
+     */
+    private static final String[] EXTERNAL_RESOURCE_LINK_REL = new String[] {
+            "dns-prefetch", "icon", "manifest", "modulepreload", "pingback", "preconnect", "prefetch", "preload", "prerender", "stylesheet"
+    };
 
     private static final String h1WarningMessage = "Consider using the"
             + " \u201Ch1\u201D element as a top-level heading only (all"
@@ -2907,6 +2914,11 @@ public class Assertions extends Checker {
                                 + " \u201Cintegrity\u201D unless attribute"
                                 + " \u201Csrc\u201D is also specified.");
                     }
+                    if (atts.getIndex("", "fetchpriority") > -1) {
+                        warn("Element \u201Cscript\u201D should not have attribute"
+                                     + " \u201Cfetchpriority\u201D unless attribute"
+                                     + " \u201Csrc\u201D is also specified.");
+                    }
                 }
                 if (atts.getIndex("", "type") > -1) {
                     String scriptType = atts.getValue("", "type").toLowerCase();
@@ -3363,6 +3375,12 @@ public class Assertions extends Checker {
                                 + " \u201Cstylesheet\u201D must have a"
                                 + " \u201Ctitle\u201D attribute with a"
                                 + " non-empty value.");
+                }
+                if (atts.getIndex("", "fetchpriority") > -1
+                        && Arrays.stream(EXTERNAL_RESOURCE_LINK_REL).noneMatch(relList::contains)) {
+                    warn("A \u201Clink\u201D element with \u201Cfetchpriority\u201D"
+                                + " attribute should have a \u201Crel\u201D"
+                                + " attribute containing external resource type.");
                 }
                 if ((ancestorMask & BODY_MASK) != 0
                         && (relList != null


### PR DESCRIPTION
This PR adds [fetchpriority](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attribute) attribute to `img`, `script` and `link` elements.

Fixes #1544

Related: [WHATWG PR](https://github.com/whatwg/html/pull/8470)