### PR TITLE
fix: Allow -1 for aria-rowcount

### DIFF
--- a/schema/html5/aria.rnc
+++ b/schema/html5/aria.rnc
@@ -576,7 +576,9 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 ## rowcount
 	aria.prop.rowcount =
 		attribute aria-rowcount {
-			common.data.integer.positive
+			(	common.data.integer.non-negative
+                        |	string "-1"
+                        )
 		}
 
 ## rowindex


### PR DESCRIPTION
Fixes #1552
Not sure if this is the entire fix, I just copied the pattern from `aria-setsize` below, since it has the same rule around interger or `-1`

https://www.w3.org/TR/wai-aria-1.2/#aria-rowcount