### PR TITLE
allow role=button on area

### DIFF
--- a/schema/html5/embed.rnc
+++ b/schema/html5/embed.rnc
@@ -600,6 +600,7 @@ namespace local = ""
 		&	shared-hyperlink.attrs.type?
 		&	area.attrs.shape?
 		&	(	common.attrs.aria.role.link
+			|	common.attrs.aria.role.button
 			|	common.attrs.aria.implicit.link
 			)?
 		)


### PR DESCRIPTION
Fixes #1249

does not fix the following (but it is not an ask from ARIA in HTML spec, just a suggestion for checker behaviour)

> As without the href the area would no longer be keyboard focusable, conformance checkers may surface a warning stating this. However, this will not be a requirement from ARIA in HTML.