### PR TITLE
Add `plaintext-only` value to `contenteditable` attribute

### DIFF
--- a/schema/html5/applications.rnc
+++ b/schema/html5/applications.rnc
@@ -18,7 +18,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 
 	common.attrs.contenteditable =
 		attribute contenteditable {
-			w:string "true" | w:string "false" | w:string ""
+			w:string "true" | w:string "plaintext-only" | w:string "false" | w:string ""
 		}
 
 ## Draggable Element: draggable


### PR DESCRIPTION
This PR adds the `plaintext-only` attribute to the `content-editable` attribute.

Fixes #1561 