### PR TITLE
Support all official CSP/iframe sandbox parameters

### DIFF
--- a/src/nu/validator/datatype/ContentSecurityPolicy.java
+++ b/src/nu/validator/datatype/ContentSecurityPolicy.java
@@ -45,8 +45,11 @@ public class ContentSecurityPolicy extends AbstractDatatype {
 
     private static final String SANDBOX_KEYWORDS = "("
             + "allow-forms|allow-modals|allow-pointer-lock"
+            + "|allow-downloads|allow-orientation-lock|allow-presentation"
             + "|allow-popups-to-escape-sandbox|allow-popups|allow-same-origin"
-            + "|allow-scripts|allow-top-navigation)";
+            + "|allow-scripts|allow-top-navigation"
+            + "|allow-top-navigation-by-user-activation"
+            + "|allow-top-navigation-to-custom-protocols)";
 
     protected ContentSecurityPolicy() {
         super();

--- a/src/nu/validator/datatype/SandboxAllowList.java
+++ b/src/nu/validator/datatype/SandboxAllowList.java
@@ -64,6 +64,7 @@ public final class SandboxAllowList extends AbstractDatatype {
         allowedKeywords.add("allow-scripts");
         allowedKeywords.add("allow-top-navigation");
         allowedKeywords.add("allow-top-navigation-by-user-activation");
+        allowedKeywords.add("allow-top-navigation-to-custom-protocols");
     }
 
     @Override


### PR DESCRIPTION
Sync both CSP and iframe sandbox parameters to the latest spec. Add these keywords to the CSP sandbox directive:

- allow-downloads
- allow-orientation-lock
- allow-presentation
- allow-top-navigation-by-user-activation
- allow-top-navigation-to-custom-protocols

Add these keywords to the iframe sandbox attribute:

- allow-top-navigation-to-custom-protocols

Relevant specification URLs:

Valid values for sandbox attributes:
<https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox>

CSP sandbox directive deferring to WHATWG HTML Living Standard: <https://www.w3.org/TR/CSP3/#directive-sandbox>

Fixes #1720