### PR TITLE
Fix "Element “html” not allowed in this context" false positive

### DIFF
--- a/src/nu/validator/client/SimpleCommandLineValidator.java
+++ b/src/nu/validator/client/SimpleCommandLineValidator.java
@@ -488,6 +488,10 @@ public class SimpleCommandLineValidator {
     }
 
     private static void checkCssFile(File file) throws IOException, Exception {
+        if (!"http://s.validator.nu/xhtml5-all.rnc".equals(
+                validator.getMainSchemaUrl()) && !hasSchemaOption) {
+            setSchema("http://s.validator.nu/xhtml5-all.rnc");
+        }
         try {
             String path = file.getPath();
             if (!file.exists()) {


### PR DESCRIPTION
CSS checks need the default schema, but SVG checks left it overridden.

The (X)HTML check already had code to detect this case and reset the schema, but it was missing for the CSS check. That meant it only failed when a CSS file was checked immediately after an SVG with no (X)HTML in between (See repro case in #1667).

Fixes #1217