### PR TITLE
Update RNC schemas for ARIA 1.2

### DIFF
--- a/schema/html5/aria.rnc
+++ b/schema/html5/aria.rnc
@@ -44,6 +44,7 @@ common.attrs.aria.implicit.button |=
 common.attrs.aria.implicit.cell |=
 	(	aria.prop.colspan?
 	&	aria.prop.rowspan?
+	&	aria.prop.colindex?	# ARIA 1.1 and 1.2
 	&	aria.prop.rowindex?
 	)
 
@@ -649,6 +650,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	aria.application =
 		(	aria.role.application
 		&	aria.state.expanded?
+		&	aria.prop.activedescendant?		# ARIA 1.1 and 1.2
 		)
 		aria.role.application = 
 			attribute role { string "application" }
@@ -660,6 +662,8 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	aria.article =
 		(	aria.role.article
 		&	aria.state.expanded?
+		&	aria.prop.posinset?		# ARIA 1.1 and 1.2
+		&	aria.prop.setsize?		# ARIA 1.1 and 1.2
 		)
 		aria.role.article = 
 			attribute role { string "article" }
@@ -707,6 +711,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	aria.checkbox =
 		(	aria.role.checkbox
 		&	aria.state.checked #required!
+		&	aria.prop.readonly? 	# ARIA 1.1 and 1.2
 		)
 		aria.role.checkbox = 
 			attribute role { string "checkbox" }
@@ -724,6 +729,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 		&	aria.prop.required?
 		&	aria.prop.colspan?
 		&	aria.prop.rowspan?
+		&	aria.prop.colindex?	# ARIA 1.1 and 1.2
 		&	aria.prop.rowindex?
 		)
 		aria.role.columnheader = 
@@ -970,6 +976,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 		&	aria.prop.required?
 		&	aria.prop.activedescendant?
 		&	aria.state.expanded?
+		&	aria.prop.readonly? # ARIA 1.1 and 1.2
 		&	aria.prop.orientation?
 		)
 		aria.role.listbox = 
@@ -1080,6 +1087,8 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	aria.menuitemcheckbox =
 		(	aria.role.menuitemcheckbox
 		&	aria.state.checked #required
+		&	aria.prop.posinset?		# ARIA 1.1 and 1.2
+		&	aria.prop.setsize?		# ARIA 1.1 and 1.2
 		)
 		aria.role.menuitemcheckbox = 
 			attribute role { string "menuitemcheckbox" }
@@ -1206,6 +1215,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 		(	aria.role.radiogroup
 		&	aria.prop.activedescendant?
 		&	aria.state.expanded?
+		&	aria.prop.readonly? # ARIA 1.1 and 1.2
 		&	aria.prop.required?
 		&	aria.prop.orientation?
 		)
@@ -1263,6 +1273,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 		&	aria.prop.required?
 		&	aria.prop.colspan?
 		&	aria.prop.rowspan?
+		&	aria.prop.colindex?	# ARIA 1.1 and 1.2
 		&	aria.prop.rowindex?
 		)
 		aria.role.rowheader = 
@@ -1276,6 +1287,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 		&	aria.prop.activedescendant?
 		&	aria.prop.autocomplete?
 		&	aria.prop.multiline?
+		&	aria.prop.placeholder?	# ARIA 1.1 and 1.2
 		&	aria.prop.readonly?
 		&	aria.prop.required?
 		)
@@ -1330,6 +1342,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 		&	aria.prop.valuemin
 		&	aria.prop.valuenow
 		&	aria.prop.valuetext?
+		&	aria.prop.readonly? 		# ARIA 1.1 and 1.2
 		&	aria.prop.orientation?
 		)
 		aria.role.slider = 
@@ -1345,6 +1358,8 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 		&	aria.prop.valuemin
 		&	aria.prop.valuenow
 		&	aria.prop.valuetext?
+		&	aria.prop.activedescendant?		# ARIA 1.1 and 1.2
+		&	aria.prop.readonly? 			# ARIA 1.1 and 1.2
 		&	aria.prop.required?
 		)
 		aria.role.spinbutton = 
@@ -1368,6 +1383,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	aria.switch =
 		(	aria.role.switch
 		&	aria.state.checked #required!
+		&	aria.prop.readonly? 	# ARIA 1.1 and 1.2
 		)
 		aria.role.switch =
 			attribute role { string "switch" }
@@ -1448,6 +1464,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 		&	aria.prop.activedescendant?
 		&	aria.prop.autocomplete? # not inherited
 		&	aria.prop.multiline? # not inherited
+		&	aria.prop.placeholder?	# ARIA 1.1 and 1.2
 		&	aria.prop.readonly? # not inherited
 		&	aria.prop.required?
 		)

--- a/schema/html5/aria.rnc
+++ b/schema/html5/aria.rnc
@@ -681,7 +681,17 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	
 	common.attrs.aria |= aria.banner
 	common.attrs.aria.landmark.banner |= aria.banner
+
+## blockquote - added in ARIA 1.2
+	aria.blockquote =
+		(	aria.role.blockquote
+		)
+		aria.role.blockquote = 
+			attribute role { string "blockquote" }
 	
+	common.attrs.aria |= aria.blockquote
+	common.attrs.aria.role.blockquote |= aria.blockquote	
+
 ## button
 	aria.button =
 		(	aria.role.button
@@ -693,6 +703,16 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	
 	common.attrs.aria |= aria.button
 	common.attrs.aria.role.button |= aria.button
+
+## caption - added in ARIA 1.2
+	aria.caption =
+		(	aria.role.caption
+		)
+		aria.role.caption = 
+			attribute role { string "caption" }
+	
+	common.attrs.aria |= aria.caption
+	common.attrs.aria.role.caption |= aria.caption
 
 ## cell
 	aria.cell =
@@ -718,6 +738,16 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	
 	common.attrs.aria |= aria.checkbox
 	common.attrs.aria.role.checkbox |= aria.checkbox
+
+## code - added in ARIA 1.2
+	aria.code =
+		(	aria.role.code
+		)
+		aria.role.code = 
+			attribute role { string "code" }
+	
+	common.attrs.aria |= aria.code
+	common.attrs.aria.role.code |= aria.code
 
 # columnheader
 	aria.columnheader =
@@ -787,6 +817,16 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	common.attrs.aria |= aria.definition
 	common.attrs.aria.role.definition |= aria.definition
 
+## deletion - added in ARIA 1.2
+	aria.deletion =
+		(	aria.role.deletion
+		)
+		aria.role.deletion = 
+			attribute role { string "deletion" }
+	
+	common.attrs.aria |= aria.deletion
+	common.attrs.aria.role.deletion |= aria.deletion
+
 ## dialog
 	aria.dialog =
 		(	aria.role.dialog
@@ -820,6 +860,16 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 
 	common.attrs.aria |= aria.document
 	common.attrs.aria.landmark.document |= aria.document
+
+## emphasis - added in ARIA 1.2
+	aria.emphasis =
+		(	aria.role.emphasis
+		)
+		aria.role.emphasis = 
+			attribute role { string "emphasis" }
+	
+	common.attrs.aria |= aria.emphasis
+	common.attrs.aria.role.emphasis |= aria.emphasis
 
 ## feed
 	aria.feed =
@@ -946,6 +996,16 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	
 	common.attrs.aria |= aria.img
 	common.attrs.aria.role.img |= aria.img
+
+## insertion - added in ARIA 1.2
+	aria.insertion =
+		(	aria.role.insertion
+		)
+		aria.role.insertion = 
+			attribute role { string "insertion" }
+	
+	common.attrs.aria |= aria.insertion
+	common.attrs.aria.role.insertion |= aria.insertion
 
 ## link
 	aria.link =
@@ -1128,6 +1188,20 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 			attribute role { string "menuitemradio" }
 	common.attrs.aria.role.menuitemradio-checked-not-required |= aria.menuitemradio-checked-not-required
 
+## meter - added in ARIA 1.2
+	aria.meter =
+		(	aria.role.meter
+		&	aria.prop.valuemax? # optional
+		&	aria.prop.valuemin? # optional
+		&	aria.prop.valuetext? # inherited
+		&	aria.prop.valuenow # required
+		)		
+		aria.role.meter = 
+			attribute role { string "meter" }
+	
+	common.attrs.aria |= aria.meter
+	common.attrs.aria.role.meter |= aria.meter
+
 ## navigation
 	aria.navigation =
 		(	aria.role.navigation
@@ -1171,6 +1245,16 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	
 	common.attrs.aria |= aria.option
 	common.attrs.aria.role.option |= aria.option
+
+## paragraph - added in ARIA 1.2
+	aria.paragraph =
+		(	aria.role.paragraph
+		)
+		aria.role.paragraph = 
+			attribute role { string "paragraph" }
+	
+	common.attrs.aria |= aria.paragraph
+	common.attrs.aria.role.paragraph |= aria.paragraph
 
 ## presentation
 	aria.presentation =
@@ -1379,6 +1463,36 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	common.attrs.aria |= aria.status
 	common.attrs.aria.role.status |= aria.status
 
+## strong - added in ARIA 1.2
+	aria.strong =
+		(	aria.role.strong
+		)
+		aria.role.strong = 
+			attribute role { string "strong" }
+	
+	common.attrs.aria |= aria.strong
+	common.attrs.aria.role.strong |= aria.strong
+
+## subscript - added in ARIA 1.2
+	aria.subscript =
+		(	aria.role.subscript
+		)
+		aria.role.subscript = 
+			attribute role { string "subscript" }
+	
+	common.attrs.aria |= aria.subscript
+	common.attrs.aria.role.subscript |= aria.subscript
+
+## superscript - added in ARIA 1.2
+	aria.superscript =
+		(	aria.role.superscript
+		)
+		aria.role.superscript = 
+			attribute role { string "superscript" }
+	
+	common.attrs.aria |= aria.superscript
+	common.attrs.aria.role.superscript |= aria.superscript
+
 ## switch
 	aria.switch =
 		(	aria.role.switch
@@ -1473,6 +1587,16 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	
 	common.attrs.aria |= aria.textbox
 	common.attrs.aria.role.textbox |= aria.textbox
+
+## time - added in ARIA 1.2
+	aria.time =
+		(	aria.role.time
+		)
+		aria.role.time = 
+			attribute role { string "time" }
+	
+	common.attrs.aria |= aria.time
+	common.attrs.aria.role.time |= aria.time
 
 ## timer
 	aria.timer =

--- a/schema/html5/aria.rnc
+++ b/schema/html5/aria.rnc
@@ -1389,9 +1389,9 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 ## scrollbar
 	aria.scrollbar =
 		(	aria.role.scrollbar
-		&	aria.prop.orientation
-		&	aria.prop.valuemax
-		&	aria.prop.valuemin
+		&	aria.prop.orientation?	# ARIA 1.2 optional
+		&	aria.prop.valuemax? 	# ARIA 1.2 optional
+		&	aria.prop.valuemin?		# ARIA 1.2 optional
 		&	aria.prop.valuenow
 		&	aria.prop.valuetext?
 		)
@@ -1432,8 +1432,8 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 ## slider
 	aria.slider =
 		(	aria.role.slider
-		&	aria.prop.valuemax
-		&	aria.prop.valuemin
+		&	aria.prop.valuemax? 		# optional in ARIA 1.2
+		&	aria.prop.valuemin? 		# optional in ARIA 1.2
 		&	aria.prop.valuenow
 		&	aria.prop.valuetext?
 		&	aria.prop.readonly? 		# ARIA 1.1 and 1.2
@@ -1448,9 +1448,9 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 ## spinbutton
 	aria.spinbutton =
 		(	aria.role.spinbutton
-		&	aria.prop.valuemax
-		&	aria.prop.valuemin
-		&	aria.prop.valuenow
+		&	aria.prop.valuemax? 			# optional in ARIA 1.2
+		&	aria.prop.valuemin? 			# optional in ARIA 1.2
+		&	aria.prop.valuenow? 			# optional in ARIA 1.2
 		&	aria.prop.valuetext?
 		&	aria.prop.activedescendant?		# ARIA 1.1 and 1.2
 		&	aria.prop.readonly? 			# ARIA 1.1 and 1.2

--- a/schema/html5/aria.rnc
+++ b/schema/html5/aria.rnc
@@ -731,7 +731,9 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	aria.checkbox =
 		(	aria.role.checkbox
 		&	aria.state.checked #required!
+		&	aria.state.expanded?	# ARIA 1.2 added
 		&	aria.prop.readonly? 	# ARIA 1.1 and 1.2
+		&	aria.prop.required? 	# ARIA 1.2 added
 		)
 		aria.role.checkbox = 
 			attribute role { string "checkbox" }
@@ -1147,6 +1149,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	aria.menuitemcheckbox =
 		(	aria.role.menuitemcheckbox
 		&	aria.state.checked #required
+		&	aria.state.expanded?	# ARIA 1.2 added
 		&	aria.prop.posinset?		# ARIA 1.1 and 1.2
 		&	aria.prop.setsize?		# ARIA 1.1 and 1.2
 		)
@@ -1167,6 +1170,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	aria.menuitemradio =
 		(	aria.role.menuitemradio
 		&	aria.state.checked #required
+		&	aria.state.expanded?	# ARIA 1.2 added
 		&	aria.state.selected?
 		&	aria.prop.posinset?
 		&	aria.prop.setsize?
@@ -1329,6 +1333,8 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 		&	aria.state.expanded?
 		&	aria.prop.colindex?
 		&	aria.prop.rowindex?
+		&	aria.prop.posinset?		# ARIA 1.2 added
+		&	aria.prop.setsize?		# ARIA 1.2 added
 		)
 		aria.role.row = 
 			attribute role { string "row" }
@@ -1412,6 +1418,10 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 		(	aria.role.separator
 		&	aria.state.expanded?
 		&	aria.prop.orientation?
+		&	aria.prop.valuenow?		# ARIA 1.2 (required if focusable, absent otherwise)
+		&	aria.prop.valuemin?		# ARIA 1.2 (optional if focusable, absent otherwise)
+		&	aria.prop.valuemax?		# ARIA 1.2 (optional if focusable, absent otherwise)
+		&	aria.prop.valuetext?	# ARIA 1.2 (optional if focusable, absent otherwise)
 		)
 		aria.role.separator = 
 			attribute role { string "separator" }
@@ -1497,7 +1507,9 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 	aria.switch =
 		(	aria.role.switch
 		&	aria.state.checked #required!
+		&	aria.state.expanded?	# ARIA 1.2 added
 		&	aria.prop.readonly? 	# ARIA 1.1 and 1.2
+		&	aria.prop.required? 	# ARIA 1.2 added
 		)
 		aria.role.switch =
 			attribute role { string "switch" }

--- a/schema/html5/aria.rnc
+++ b/schema/html5/aria.rnc
@@ -927,7 +927,7 @@ common.attrs.aria.implicit.navigation |= common.attrs.aria.implicit.landmark
 ## heading
 	aria.heading =
 		(	aria.role.heading
-		&	aria.prop.level ? # not inherited
+		&	aria.prop.level 	# ARIA 1.1 and 1.2 required
 		&	aria.state.expanded?
 		)
 		aria.role.heading =


### PR DESCRIPTION
This PR addresses following:

- support new roles added in ARIA 1.2 (blockquote, caption, code, deletion, emphasis, insertion, meter, paragraph, strong, subscript, superscript, time - see https://www.w3.org/TR/wai-aria-1.2/#changelog)
- add missing ARIA 1.1 and 1.2 props (e.g. several roles have aria-rowspan, aria-colspan and aria-rowindex but missed out aria-colindex)
- aria-level on role=heading was marked as optional in schema but is normatively required in ARIA 1.1 and 1.2
- add new ARIA 1.2 supported props 
- some required ARIA 1.1 props are optional in ARIA 1.2 (e.g. aria-valuemin and aria-valuemax)