### PR TITLE
Add slf4j-api-*.jar to vnu.war build

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -232,6 +232,7 @@ DEALINGS IN THE SOFTWARE.
       <fileset file="../dependencies/salvation-${salvation-version}.jar"/>
       <fileset file="../dependencies/jchardet-${jchardet-version}.jar"/>
       <fileset file="../dependencies/log4j-${log4j-version}.jar"/>
+      <fileset file="../dependencies/slf4j-api-${slf4j-api-version}.jar"/>
       <fileset file="../dependencies/jetty-util-ajax-${jetty-version}.jar"/>
       <fileset file="../dependencies/jetty-util-${jetty-version}.jar"/>
       <fileset file="../dependencies/jetty-util-${jetty-version}.jar"/>


### PR DESCRIPTION
This PR adds `slf4j-api-${slf4j-api-version}.jar` to vnu.war.

Without this jar, the latest vnu.war on Tomcat 10 of Ubuntu 24.04 noble causes an error below:
```
[2024-10-31 16:14:07] [info] ERROR VerifierServletTransaction - Error, doc: http://validator.test/ schema:  lax: false
[2024-10-31 16:14:07] [info] java.lang.NoClassDefFoundError: org/slf4j/LoggerFactory
```

<details>
<summary>full stack trace</summary>

```
root@validator:/var/log/tomcat10# tail -75 catalina.out
[2024-10-31 16:14:07] [info] INFO  PrudentHttpEntityResolver - http://validator.test/
[2024-10-31 16:14:07] [info] ERROR VerifierServletTransaction - Error, doc: http://validator.test/ schema:  lax: false
[2024-10-31 16:14:07] [info] java.lang.NoClassDefFoundError: org/slf4j/LoggerFactory
[2024-10-31 16:14:07] [info] #011at org.eclipse.jetty.util.ajax.JSON.<clinit>(JSON.java:84)
[2024-10-31 16:14:07] [info] #011at com.cybozu.labs.langdetect.DetectorFactory.loadProfile(DetectorFactory.java:127)
[2024-10-31 16:14:07] [info] #011at nu.validator.checker.LanguageDetectingChecker.<clinit>(LanguageDetectingChecker.java:215)
[2024-10-31 16:14:07] [info] #011at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
[2024-10-31 16:14:07] [info] #011at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1160)
[2024-10-31 16:14:07] [info] #011at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.ensureClassInitialized(MethodHandleAccessorFactory.java:300)
[2024-10-31 16:14:07] [info] #011at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newConstructorAccessor(MethodHandleAccessorFactory.java:103)
[2024-10-31 16:14:07] [info] #011at java.base/jdk.internal.reflect.ReflectionFactory.newConstructorAccessor(ReflectionFactory.java:200)
[2024-10-31 16:14:07] [info] #011at java.base/java.lang.reflect.Constructor.acquireConstructorAccessor(Constructor.java:549)
[2024-10-31 16:14:07] [info] #011at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
[2024-10-31 16:14:07] [info] #011at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
[2024-10-31 16:14:07] [info] #011at nu.validator.checker.jing.CheckerSchema.createValidator(CheckerSchema.java:91)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.VerifierServletTransaction.validatorByUrl(VerifierServletTransaction.java:1821)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.VerifierServletTransaction.combineValidatorByUrl(VerifierServletTransaction.java:1788)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.VerifierServletTransaction.validatorByUrls(VerifierServletTransaction.java:1765)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.VerifierServletTransaction.validatorByDoctype(VerifierServletTransaction.java:1702)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.VerifierServletTransaction.documentMode(VerifierServletTransaction.java:2236)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.impl.TreeBuilder.documentModeInternal(TreeBuilder.java:4158)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.impl.TreeBuilder.doctype(TreeBuilder.java:777)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.impl.Tokenizer.emitDoctypeToken(Tokenizer.java:7046)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.impl.Tokenizer.stateLoop(Tokenizer.java:5172)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.impl.Tokenizer.tokenizeBuffer(Tokenizer.java:1488)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.io.Driver.runStates(Driver.java:319)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.io.Driver.tokenize(Driver.java:236)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.io.Driver.tokenize(Driver.java:177)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.sax.HtmlParser.tokenize(HtmlParser.java:536)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.sax.HtmlParser.parse(HtmlParser.java:415)
[2024-10-31 16:14:07] [info] #011at nu.validator.htmlparser.sax.HtmlParser.parse(HtmlParser.java:405)
[2024-10-31 16:14:07] [info] #011at nu.validator.xml.WiretapXMLReaderWrapper.parse(WiretapXMLReaderWrapper.java:158)
[2024-10-31 16:14:07] [info] #011at nu.validator.xml.AttributesPermutingXMLReaderWrapper.parse(AttributesPermutingXMLReaderWrapper.java:303)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.VerifierServletTransaction.validate(VerifierServletTransaction.java:1177)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.PageEmitter.emit(PageEmitter.java:60)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.VerifierServletTransaction.service(VerifierServletTransaction.java:956)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.VerifierServlet.doPost(VerifierServlet.java:304)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.VerifierServlet.doGet(VerifierServlet.java:212)
[2024-10-31 16:14:07] [info] #011at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:564)
[2024-10-31 16:14:07] [info] #011at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:205)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
[2024-10-31 16:14:07] [info] #011at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.MultipartFormDataFilter.doFilter(MultipartFormDataFilter.java:199)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.InboundGzipFilter.doFilter(InboundGzipFilter.java:60)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
[2024-10-31 16:14:07] [info] #011at nu.validator.servlet.InboundSizeLimitFilter.doFilter(InboundSizeLimitFilter.java:63)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:174)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:149)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:673)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:340)
[2024-10-31 16:14:07] [info] #011at org.apache.coyote.ajp.AjpProcessor.service(AjpProcessor.java:431)
[2024-10-31 16:14:07] [info] #011at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
[2024-10-31 16:14:07] [info] #011at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:896)
[2024-10-31 16:14:07] [info] #011at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1744)
[2024-10-31 16:14:07] [info] #011at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
[2024-10-31 16:14:07] [info] #011at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
[2024-10-31 16:14:07] [info] #011at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
[2024-10-31 16:14:07] [info] #011at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
[2024-10-31 16:14:07] [info] #011at java.base/java.lang.Thread.run(Thread.java:1583)
[2024-10-31 16:14:07] [info] Caused by: java.lang.ClassNotFoundException: org.slf4j.LoggerFactory
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1353)
[2024-10-31 16:14:07] [info] #011at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1165)
[2024-10-31 16:14:07] [info] #011... 68 more
```

</details>

Only `slf4j-api-*.jar` is needed for just resolving this error, but `slf4j-log4j12-*.jar` may also be needed as well as `vnu.jar` (sorry, I don't know much about this).
https://github.com/validator/validator/blob/7d62ce104be8319ff3cd01fc904bc594afde4010/build/build.xml#L133