### PR TITLE
Add match for <search>

### DIFF
--- a/schema/html5/block.rnc
+++ b/schema/html5/block.rnc
@@ -286,3 +286,16 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	h6.elem?
 		&	hgroup.elem?
 		)
+
+## Search Container: <search>
+
+	search.elem =
+		element div { search.inner & search.attrs }
+	search.attrs =
+		(	common.attrs
+		&	common.attrs.aria?
+		)
+	search.inner =
+		( common.inner.flow )
+	
+	common.elem.flow |= search.elem


### PR DESCRIPTION
Should fix [#1478](https://github.com/validator/validator/issues/1748), however I wasn't able to test it on my local machine, as it seems that the schemes are forcibly taken from s.validator.nu, ignoring local files. Is there a way to locally test schemes?

I currently just copied the requirements for `<div>` it's very possible this is incomplete, please let me know what should I change.