### PR TITLE
Allow separator role on button elements

### DIFF
--- a/schema/html5/web-forms.rnc
+++ b/schema/html5/web-forms.rnc
@@ -173,6 +173,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 			|	common.attrs.aria.role.menuitemradio
 			|	common.attrs.aria.role.option
 			|	common.attrs.aria.role.radio
+			|	common.attrs.aria.role.separator
 			|	common.attrs.aria.role.switch
 			|	common.attrs.aria.role.tab
 			)?
@@ -297,6 +298,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 			|	common.attrs.aria.role.menuitemcheckbox
 			|	common.attrs.aria.role.menuitemradio
 			|	common.attrs.aria.role.radio
+			|	common.attrs.aria.role.separator
 			|	common.attrs.aria.role.switch
 			)?
 		)	
@@ -466,6 +468,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 			|	common.attrs.aria.role.menuitemradio
 			|	common.attrs.aria.role.option
 			|	common.attrs.aria.role.radio
+			|	common.attrs.aria.role.separator
 			|	common.attrs.aria.role.tab
 			)?
 		)
@@ -494,6 +497,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 			|	common.attrs.aria.role.menuitemradio
 			|	common.attrs.aria.role.option
 			|	common.attrs.aria.role.radio
+			|	common.attrs.aria.role.separator
 			|	common.attrs.aria.role.switch
 			)?
 		)
@@ -522,6 +526,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 			|	common.attrs.aria.role.menuitemradio
 			|	common.attrs.aria.role.option
 			|	common.attrs.aria.role.radio
+			|	common.attrs.aria.role.separator
 			|	common.attrs.aria.role.switch
 			|	common.attrs.aria.role.tab
 			)?


### PR DESCRIPTION
closes #1646

i believe i've added the allowance for role=separator into all the correct places, to close the linked issue.