### PR TITLE
Don't create the DetectorFactory object if no language detection.

### DIFF
--- a/src/nu/validator/checker/LanguageDetectingChecker.java
+++ b/src/nu/validator/checker/LanguageDetectingChecker.java
@@ -102,120 +102,122 @@ public class LanguageDetectingChecker extends Checker {
             "summary", "td", "textarea", "th", "tr" };
 
     static {
-        LANG_TAGS_BY_TLD.put("ae", new String[] { "ar" });
-        LANG_TAGS_BY_TLD.put("af", new String[] { "ps" });
-        LANG_TAGS_BY_TLD.put("am", new String[] { "hy" });
-        LANG_TAGS_BY_TLD.put("ar", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("at", new String[] { "de" });
-        LANG_TAGS_BY_TLD.put("az", new String[] { "az" });
-        LANG_TAGS_BY_TLD.put("ba", new String[] { "bs", "hr", "sr" });
-        LANG_TAGS_BY_TLD.put("bd", new String[] { "bn" });
-        LANG_TAGS_BY_TLD.put("be", new String[] { "de", "fr", "nl" });
-        LANG_TAGS_BY_TLD.put("bg", new String[] { "bg" });
-        LANG_TAGS_BY_TLD.put("bh", new String[] { "ar" });
-        LANG_TAGS_BY_TLD.put("bo", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("br", new String[] { "pt" });
-        LANG_TAGS_BY_TLD.put("by", new String[] { "be" });
-        LANG_TAGS_BY_TLD.put("bz", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("ch", new String[] { "de", "fr", "it", "rm" });
-        LANG_TAGS_BY_TLD.put("cl", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("co", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("cu", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("cr", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("cz", new String[] { "cs" });
-        LANG_TAGS_BY_TLD.put("de", new String[] { "de" });
-        LANG_TAGS_BY_TLD.put("dk", new String[] { "da" });
-        LANG_TAGS_BY_TLD.put("do", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("ec", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("ee", new String[] { "et" });
-        LANG_TAGS_BY_TLD.put("eg", new String[] { "ar" });
-        LANG_TAGS_BY_TLD.put("es", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("fi", new String[] { "fi" });
-        LANG_TAGS_BY_TLD.put("fr", new String[] { "fr" });
-        LANG_TAGS_BY_TLD.put("ge", new String[] { "ka" });
-        LANG_TAGS_BY_TLD.put("gr", new String[] { "el" });
-        LANG_TAGS_BY_TLD.put("gt", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("hn", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("hr", new String[] { "hr" });
-        LANG_TAGS_BY_TLD.put("hu", new String[] { "hu" });
-        LANG_TAGS_BY_TLD.put("id", new String[] { "id" });
-        LANG_TAGS_BY_TLD.put("is", new String[] { "is" });
-        LANG_TAGS_BY_TLD.put("it", new String[] { "it" });
-        LANG_TAGS_BY_TLD.put("il", new String[] { "iw" });
-        LANG_TAGS_BY_TLD.put("in", new String[] { "bn", "gu", "hi", "kn", "ml", "mr", "pa", "ta", "te" });
-        LANG_TAGS_BY_TLD.put("ja", new String[] { "jp" });
-        LANG_TAGS_BY_TLD.put("jo", new String[] { "ar" });
-        LANG_TAGS_BY_TLD.put("ke", new String[] { "sw" });
-        LANG_TAGS_BY_TLD.put("kg", new String[] { "ky" });
-        LANG_TAGS_BY_TLD.put("kh", new String[] { "km" });
-        LANG_TAGS_BY_TLD.put("kr", new String[] { "ko" });
-        LANG_TAGS_BY_TLD.put("kw", new String[] { "ar" });
-        LANG_TAGS_BY_TLD.put("kz", new String[] { "kk" });
-        LANG_TAGS_BY_TLD.put("la", new String[] { "lo" });
-        LANG_TAGS_BY_TLD.put("li", new String[] { "de" });
-        LANG_TAGS_BY_TLD.put("lb", new String[] { "ar" });
-        LANG_TAGS_BY_TLD.put("lk", new String[] { "si", "ta" });
-        LANG_TAGS_BY_TLD.put("lt", new String[] { "lt" });
-        LANG_TAGS_BY_TLD.put("lu", new String[] { "de" });
-        LANG_TAGS_BY_TLD.put("lv", new String[] { "lv" });
-        LANG_TAGS_BY_TLD.put("md", new String[] { "mo" });
-        LANG_TAGS_BY_TLD.put("mk", new String[] { "mk" });
-        LANG_TAGS_BY_TLD.put("mn", new String[] { "mn" });
-        LANG_TAGS_BY_TLD.put("mx", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("my", new String[] { "ms" });
-        LANG_TAGS_BY_TLD.put("ni", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("nl", new String[] { "nl" });
-        LANG_TAGS_BY_TLD.put("no", new String[] { "nn", "no" });
-        LANG_TAGS_BY_TLD.put("np", new String[] { "ne" });
-        LANG_TAGS_BY_TLD.put("pa", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("pe", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("ph", new String[] { "tl" });
-        LANG_TAGS_BY_TLD.put("pl", new String[] { "pl" });
-        LANG_TAGS_BY_TLD.put("pk", new String[] { "ur" });
-        LANG_TAGS_BY_TLD.put("pr", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("pt", new String[] { "pt" });
-        LANG_TAGS_BY_TLD.put("py", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("qa", new String[] { "ar" });
-        LANG_TAGS_BY_TLD.put("ro", new String[] { "ro" });
-        LANG_TAGS_BY_TLD.put("rs", new String[] { "sr" });
-        LANG_TAGS_BY_TLD.put("ru", new String[] { "ru" });
-        LANG_TAGS_BY_TLD.put("sa", new String[] { "ar" });
-        LANG_TAGS_BY_TLD.put("se", new String[] { "sv" });
-        LANG_TAGS_BY_TLD.put("si", new String[] { "sl" });
-        LANG_TAGS_BY_TLD.put("sk", new String[] { "sk" });
-        LANG_TAGS_BY_TLD.put("sv", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("th", new String[] { "th" });
-        LANG_TAGS_BY_TLD.put("tj", new String[] { "tg" });
-        LANG_TAGS_BY_TLD.put("tm", new String[] { "tk" });
-        LANG_TAGS_BY_TLD.put("ua", new String[] { "uk" });
-        LANG_TAGS_BY_TLD.put("uy", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("uz", new String[] { "uz" });
-        LANG_TAGS_BY_TLD.put("ve", new String[] { "es" });
-        LANG_TAGS_BY_TLD.put("vn", new String[] { "vi" });
-        LANG_TAGS_BY_TLD.put("za", new String[] { "af" });
-        try {
-            BufferedReader br = new BufferedReader(new InputStreamReader(
-                    LanguageDetectingChecker.class.getClassLoader() //
-                            .getResourceAsStream(languageList),
-                    "UTF-8"));
-            List<String> languageTags = new ArrayList<>();
-            String languageTagAndName = br.readLine();
-            while (languageTagAndName != null) {
-                languageTags.add(languageTagAndName.split("\t")[0]);
-                languageTagAndName = br.readLine();
-            }
-            List<String> profiles = new ArrayList<>();
-            for (String languageTag : languageTags) {
-                profiles.add((new BufferedReader(new InputStreamReader(
+        if (!"0".equals(System.getProperty("nu.validator.checker.enableLangDetection"))) {
+            LANG_TAGS_BY_TLD.put("ae", new String[] { "ar" });
+            LANG_TAGS_BY_TLD.put("af", new String[] { "ps" });
+            LANG_TAGS_BY_TLD.put("am", new String[] { "hy" });
+            LANG_TAGS_BY_TLD.put("ar", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("at", new String[] { "de" });
+            LANG_TAGS_BY_TLD.put("az", new String[] { "az" });
+            LANG_TAGS_BY_TLD.put("ba", new String[] { "bs", "hr", "sr" });
+            LANG_TAGS_BY_TLD.put("bd", new String[] { "bn" });
+            LANG_TAGS_BY_TLD.put("be", new String[] { "de", "fr", "nl" });
+            LANG_TAGS_BY_TLD.put("bg", new String[] { "bg" });
+            LANG_TAGS_BY_TLD.put("bh", new String[] { "ar" });
+            LANG_TAGS_BY_TLD.put("bo", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("br", new String[] { "pt" });
+            LANG_TAGS_BY_TLD.put("by", new String[] { "be" });
+            LANG_TAGS_BY_TLD.put("bz", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("ch", new String[] { "de", "fr", "it", "rm" });
+            LANG_TAGS_BY_TLD.put("cl", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("co", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("cu", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("cr", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("cz", new String[] { "cs" });
+            LANG_TAGS_BY_TLD.put("de", new String[] { "de" });
+            LANG_TAGS_BY_TLD.put("dk", new String[] { "da" });
+            LANG_TAGS_BY_TLD.put("do", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("ec", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("ee", new String[] { "et" });
+            LANG_TAGS_BY_TLD.put("eg", new String[] { "ar" });
+            LANG_TAGS_BY_TLD.put("es", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("fi", new String[] { "fi" });
+            LANG_TAGS_BY_TLD.put("fr", new String[] { "fr" });
+            LANG_TAGS_BY_TLD.put("ge", new String[] { "ka" });
+            LANG_TAGS_BY_TLD.put("gr", new String[] { "el" });
+            LANG_TAGS_BY_TLD.put("gt", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("hn", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("hr", new String[] { "hr" });
+            LANG_TAGS_BY_TLD.put("hu", new String[] { "hu" });
+            LANG_TAGS_BY_TLD.put("id", new String[] { "id" });
+            LANG_TAGS_BY_TLD.put("is", new String[] { "is" });
+            LANG_TAGS_BY_TLD.put("it", new String[] { "it" });
+            LANG_TAGS_BY_TLD.put("il", new String[] { "iw" });
+            LANG_TAGS_BY_TLD.put("in", new String[] { "bn", "gu", "hi", "kn", "ml", "mr", "pa", "ta", "te" });
+            LANG_TAGS_BY_TLD.put("ja", new String[] { "jp" });
+            LANG_TAGS_BY_TLD.put("jo", new String[] { "ar" });
+            LANG_TAGS_BY_TLD.put("ke", new String[] { "sw" });
+            LANG_TAGS_BY_TLD.put("kg", new String[] { "ky" });
+            LANG_TAGS_BY_TLD.put("kh", new String[] { "km" });
+            LANG_TAGS_BY_TLD.put("kr", new String[] { "ko" });
+            LANG_TAGS_BY_TLD.put("kw", new String[] { "ar" });
+            LANG_TAGS_BY_TLD.put("kz", new String[] { "kk" });
+            LANG_TAGS_BY_TLD.put("la", new String[] { "lo" });
+            LANG_TAGS_BY_TLD.put("li", new String[] { "de" });
+            LANG_TAGS_BY_TLD.put("lb", new String[] { "ar" });
+            LANG_TAGS_BY_TLD.put("lk", new String[] { "si", "ta" });
+            LANG_TAGS_BY_TLD.put("lt", new String[] { "lt" });
+            LANG_TAGS_BY_TLD.put("lu", new String[] { "de" });
+            LANG_TAGS_BY_TLD.put("lv", new String[] { "lv" });
+            LANG_TAGS_BY_TLD.put("md", new String[] { "mo" });
+            LANG_TAGS_BY_TLD.put("mk", new String[] { "mk" });
+            LANG_TAGS_BY_TLD.put("mn", new String[] { "mn" });
+            LANG_TAGS_BY_TLD.put("mx", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("my", new String[] { "ms" });
+            LANG_TAGS_BY_TLD.put("ni", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("nl", new String[] { "nl" });
+            LANG_TAGS_BY_TLD.put("no", new String[] { "nn", "no" });
+            LANG_TAGS_BY_TLD.put("np", new String[] { "ne" });
+            LANG_TAGS_BY_TLD.put("pa", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("pe", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("ph", new String[] { "tl" });
+            LANG_TAGS_BY_TLD.put("pl", new String[] { "pl" });
+            LANG_TAGS_BY_TLD.put("pk", new String[] { "ur" });
+            LANG_TAGS_BY_TLD.put("pr", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("pt", new String[] { "pt" });
+            LANG_TAGS_BY_TLD.put("py", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("qa", new String[] { "ar" });
+            LANG_TAGS_BY_TLD.put("ro", new String[] { "ro" });
+            LANG_TAGS_BY_TLD.put("rs", new String[] { "sr" });
+            LANG_TAGS_BY_TLD.put("ru", new String[] { "ru" });
+            LANG_TAGS_BY_TLD.put("sa", new String[] { "ar" });
+            LANG_TAGS_BY_TLD.put("se", new String[] { "sv" });
+            LANG_TAGS_BY_TLD.put("si", new String[] { "sl" });
+            LANG_TAGS_BY_TLD.put("sk", new String[] { "sk" });
+            LANG_TAGS_BY_TLD.put("sv", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("th", new String[] { "th" });
+            LANG_TAGS_BY_TLD.put("tj", new String[] { "tg" });
+            LANG_TAGS_BY_TLD.put("tm", new String[] { "tk" });
+            LANG_TAGS_BY_TLD.put("ua", new String[] { "uk" });
+            LANG_TAGS_BY_TLD.put("uy", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("uz", new String[] { "uz" });
+            LANG_TAGS_BY_TLD.put("ve", new String[] { "es" });
+            LANG_TAGS_BY_TLD.put("vn", new String[] { "vi" });
+            LANG_TAGS_BY_TLD.put("za", new String[] { "af" });
+            try {
+                BufferedReader br = new BufferedReader(new InputStreamReader(
                         LanguageDetectingChecker.class.getClassLoader() //
-                                .getResourceAsStream(profilesDir + languageTag),
-                        "UTF-8"))).readLine());
+                                .getResourceAsStream(languageList),
+                        "UTF-8"));
+                List<String> languageTags = new ArrayList<>();
+                String languageTagAndName = br.readLine();
+                while (languageTagAndName != null) {
+                    languageTags.add(languageTagAndName.split("\t")[0]);
+                    languageTagAndName = br.readLine();
+                }
+                List<String> profiles = new ArrayList<>();
+                for (String languageTag : languageTags) {
+                    profiles.add((new BufferedReader(new InputStreamReader(
+                            LanguageDetectingChecker.class.getClassLoader() //
+                                    .getResourceAsStream(profilesDir + languageTag),
+                            "UTF-8"))).readLine());
+                }
+                DetectorFactory.clear();
+                DetectorFactory.loadProfile(profiles);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            } catch (LangDetectException e) {
             }
-            DetectorFactory.clear();
-            DetectorFactory.loadProfile(profiles);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (LangDetectException e) {
         }
     }
 
@@ -605,9 +607,9 @@ public class LanguageDetectingChecker extends Checker {
         if (!"0".equals(System.getProperty(
                 "nu.validator.checker.enableLangDetection"))
                 && htmlStartTagLocator != null) {
-            detectLanguageAndCheckAgainstDeclaredLanguage();
+                detectLanguageAndCheckAgainstDeclaredLanguage();
+            }
         }
-    }
 
     private void warnIfMissingLang() throws SAXException {
         if (!htmlElementHasLang) {


### PR DESCRIPTION
The memory-consuming DetectorFactory object is only created if the system property "nu.validator.checker.enableLangDetection" is set to "1."