### PR TITLE
fix: correct formatting and grammar issues […]

### DIFF
--- a/site/spec2.html
+++ b/site/spec2.html
@@ -176,7 +176,7 @@
       </ul>
 
      <li><a href="#terminology"><span class=secno>1.4. </span>Terminology</a>
-      
+
       <ul class=toc>
        <li><a href="#html-vs"><span class=secno>1.4.1. </span>HTML vs
         XHTML</a>
@@ -365,7 +365,7 @@
       </ul>
 
      <li><a href="#interaction"><span class=secno>3.5. </span>Interaction</a>
-      
+
       <ul class=toc>
        <li><a href="#activation"><span class=secno>3.5.1.
         </span>Activation</a>
@@ -519,7 +519,7 @@
       </ul>
 
      <li><a href="#phrase"><span class=secno>3.12. </span>Phrase elements</a>
-      
+
       <ul class=toc>
        <li><a href="#the-a"><span class=secno>3.12.1. </span>The
         <code>a</code> element</a>
@@ -1137,7 +1137,7 @@
 
      <li><a href="#content-type-sniffing"><span class=secno>4.9.
       </span>Determining the type of a new resource in a browsing context</a>
-      
+
       <ul class=toc>
        <li><a href="#content-type0"><span class=secno>4.9.1.
         </span>Content-Type sniffing: text or binary</a>
@@ -1227,7 +1227,7 @@
        <li><a href="#privacy"><span class=secno>4.11.7. </span>Privacy</a>
 
        <li><a href="#security6"><span class=secno>4.11.8. </span>Security</a>
-        
+
         <ul class=toc>
          <li><a href="#user-agents"><span class=secno>4.11.8.1. </span>User
           agents</a>
@@ -1980,7 +1980,7 @@
     1937. http://www.turingarchive.org/browse.php/B/12 (referenced:
     2007-03-03)
     -->
-    
+
     <p>The term "HTML5 validator" can be used to refer to a conformance
      checker that itself conforms to the applicable requirements of this
      specification.</p>
@@ -2570,8 +2570,8 @@
   <a href="#selection1">Selection</a> <a href="#getselection0" title=dom-document-getSelection>getSelection</a>();
 
 <!-- XXX we're not done here.
-     XXX see e.g. http://lxr.mozilla.org/seamonkey/source/dom/public/idl/html/nsIDOMNSHTMLDocument.idl 
-     XXX see e.g. http://trac.webkit.org/projects/webkit/browser/trunk/WebCore/dom/Document.cpp 
+     XXX see e.g. http://lxr.mozilla.org/seamonkey/source/dom/public/idl/html/nsIDOMNSHTMLDocument.idl
+     XXX see e.g. http://trac.webkit.org/projects/webkit/browser/trunk/WebCore/dom/Document.cpp
      XXX see e.g. http://trac.webkit.org/projects/webkit/browser/trunk/WebCore/html/HTMLDocument.cpp
   -->
 };</pre>
@@ -4085,7 +4085,7 @@ data:text/xml,<script xmlns="http://www.w3.org/1999/xhtml"><![CDATA[ alert('test
      <var title="">new children</var> be the children of the document,
      preserving their order. Otherwise, the attribute is being set on an
      <code>Element</code> node; let <var title="">new children</var> be the
-     children of the the document's root element, preserving their order.</p>
+     children of the document's root element, preserving their order.</p>
 
    <li>
     <p>If the attribute is being set on a <code>Document</code> node, let
@@ -7568,7 +7568,7 @@ onActivate, onBeforeDeactivate, onDeactivate, document.hasFocus):
    title=attr-meta-http-equiv><code>http-equiv</code></dfn> attribute is an
    <a href="#enumerated">enumerated attribute</a>. The following table lists
    the keywords defined for this attribute. The states given in the first
-   cell of the the rows with keywords give the states to which those keywords
+   cell of the rows with keywords give the states to which those keywords
    map.<!-- Some of the keywords are non-conforming, as
   noted in the last column.-->
 
@@ -7618,7 +7618,7 @@ onActivate, onBeforeDeactivate, onDeactivate, document.hasFocus):
 
   <dl>
    <dt><dfn id=refresh title=attr-meta-http-equiv-refresh>Refresh state</dfn>
-    
+
 
    <dd>
     <ol><!-- TESTS: http://www.hixie.ch/tests/adhoc/html/meta/refresh/ -->
@@ -8559,8 +8559,8 @@ XXX attributes to give the date authored, date published
     the following contact information:</p>
 
    <pre>&lt;ADDRESS>
- &lt;A href="../People/Raggett/">Dave Raggett&lt;/A>, 
- &lt;A href="../People/Arnaud/">Arnaud Le Hors&lt;/A>, 
+ &lt;A href="../People/Raggett/">Dave Raggett&lt;/A>,
+ &lt;A href="../People/Arnaud/">Arnaud Le Hors&lt;/A>,
  contact persons for the &lt;A href="Activity">W3C HTML Activity&lt;/A>
 &lt;/ADDRESS></pre>
   </div>
@@ -9362,7 +9362,7 @@ Address: &lt;input name="address"&gt;&lt;/p&gt;</pre>
  &lt;dt> Costello
  &lt;dd> When you pay off the first baseman every month, who gets the money?
  &lt;dt> Abbott
- &lt;dd> Every dollar of it. 
+ &lt;dd> Every dollar of it.
 &lt;/dialog></pre>
   </div>
 
@@ -11521,7 +11521,7 @@ For example, the 10th point has coordinate
 
   <div class=example>
    <pre>&lt;p>The most beautiful women are
-&lt;span lang="fr">&lt;abbr>M&lt;sup>lle&lt;/sup>&lt;/abbr> Gwendoline&lt;/span> and 
+&lt;span lang="fr">&lt;abbr>M&lt;sup>lle&lt;/sup>&lt;/abbr> Gwendoline&lt;/span> and
 &lt;span lang="fr">&lt;abbr>M&lt;sup>me&lt;/sup>&lt;/abbr> Denise&lt;/span>.&lt;/p></pre>
   </div>
 
@@ -12193,7 +12193,7 @@ brighter. A &lt;b>rat&lt;/b> scurries past the corner wall.&lt;/p></pre>
 
     <p>The text must be given in the <code title=attr-img-alt><a
      href="#alt">alt</a></code> attribute, and must convey the same message
-     as the the image specified in the <code title=attr-img-src><a
+     as the image specified in the <code title=attr-img-src><a
      href="#src">src</a></code> attribute.</p>
 
     <div class=example>
@@ -13643,9 +13643,9 @@ The island of Shalott.&lt;/p></pre>
     * general meta data, implemented as getters (don't expose the whole thing)
       - getMetadata(key: string, language: string) => HTMLImageElement or string
       - onmetadatachanged (no context info)
-    * video: changing the playback aspect ratio 
-    * video: applying CSS filters 
-    * infinite looping 
+    * video: changing the playback aspect ratio
+    * video: applying CSS filters
+    * infinite looping
   -->
 
   <p><a href="#media5" title="media element">Media elements</a> are used to
@@ -14064,7 +14064,7 @@ The island of Shalott.&lt;/p></pre>
       rendered at all
 
      <dd>
-      <p>The server returning a file of the wrong kind (e.g. one that that
+      <p>The server returning a file of the wrong kind (e.g. one that
        turns out to not be pure audio when the <a href="#media5">media
        element</a> is an <code><a href="#audio1">audio</a></code> element),
        or the file using unsupported codecs for all the data, must cause the
@@ -15360,7 +15360,7 @@ The island of Shalott.&lt;/p></pre>
 
      <td>The user agent is fetching <a href="#media7">media data</a>, and the
       <a href="#media8">media resource</a>'s metadata has just been received.
-      
+
 
      <td><code title=dom-media-networkState><a
       href="#networkstate">networkState</a></code> equals <code
@@ -15419,7 +15419,7 @@ The island of Shalott.&lt;/p></pre>
      <td><code>ProgressEvent</code> <a href="#refsPROGRESS">[PROGRESS]</a>
 
      <td>An error occurs while fetching the <a href="#media7">media data</a>.
-      
+
 
      <td><code title=dom-media-error><a href="#error0">error</a></code> is an
       object with the code <code
@@ -16742,7 +16742,7 @@ interface <dfn id=imagedata>ImageData</dfn> {
 
   <p>The <dfn id=linejoin
    title=dom-context-2d-lineJoin><code>lineJoin</code></dfn> attribute
-   defines the type of corners that that UAs will place where two lines meet.
+   defines the type of corners that UAs will place where two lines meet.
    The three valid values are <code>round</code>, <code>bevel</code>, and
    <code>miter</code>.
 
@@ -17491,7 +17491,7 @@ notes on what would need to be defined for dashed lines:
   <p>The <dfn id=shape title=attr-area-shape><code>shape</code></dfn>
    attribute is an <a href="#enumerated">enumerated attribute</a>. The
    following table lists the keywords defined for this attribute. The states
-   given in the first cell of the the rows with keywords give the states to
+   given in the first cell of the rows with keywords give the states to
    which those keywords map. Some of the keywords are non-conforming, as
    noted in the last column.
 
@@ -17915,7 +17915,7 @@ notes on what would need to be defined for dashed lines:
         browsers implement the even-odd rule / even winding rule:
         http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C%21DOCTYPE%20html%3E%0A%3Cimg%20usemap%3D%22%23x%22%20src%3D%22/resources/images/sample%22%3E%0A%3Cmap%20name%3D%22x%22%3E%0A%20%20%3Carea%20shape%3Dpolygon%20coords%3D%220%2C0%200%2C100%20100%2C100%20100%2C2%201%2C2%202%2C1%202%2C99%2099%2C99%2099%2C0%22%20href%3Da%3E%0A%3C/map%3E%0A
        -->
-      
+
 
      <dt><a href="#rectangle" title=attr-area-shape-rect>Rectangle state</a>
 
@@ -19878,12 +19878,12 @@ notes on what would need to be defined for dashed lines:
       ready. <span class=big-issue>This isn't compatible with IE for inline
       deferred scripts, but then what IE does is pretty hard to pin down
       exactly. Do we want to keep this like it is? Be more compatible?</span>
-      <!--XXX  
+      <!--XXX
      http://www.websiteoptimization.com/speed/tweak/defer/test/
      internal deferred scripts execute before any external scripts execute, or before the LOAD if there are none
      external deferred scripts execute before the LOAD
      -->
-      
+
 
      <dt>If the element has an <code title=attr-script-async><a
       href="#async">async</a></code> attribute and a <code
@@ -21202,7 +21202,7 @@ interface <dfn id=datagriddataprovider>DataGridDataProvider</dfn> {
      element. Otherwise, the URI of the row's image is the empty string.</p>
     <!-- XXX well. that sentence could
     have gone better, that's for sure. -->
-    
+
     <p><strong><code title=dom-provider-getRowMenu><a
      href="#getrowmenu">getRowMenu(<var
      title="">i</var>)</a></code></strong>: If the row's first cell's element
@@ -22769,7 +22769,7 @@ XXX selection ranges -->
 
   <p>If a <code title=event-change>change</code> event bubbles through a
    <code><a href="#menu">menu</a></code> element, then, in addition to any
-   other default action that that event might have, the UA must act as if the
+   other default action that event might have, the UA must act as if the
    following was an additional default action for that event: if (when it
    comes time to execute the default action) the <code><a
    href="#menu">menu</a></code> element has an <code
@@ -23136,14 +23136,14 @@ XXX selection ranges -->
        the members of this interface use cross-references with the title
        dom-command-ro-foo (note the "ro", which stands for "readonly").
 -->
-  readonly attribute DOMString <a href="#commandtype" title=dom-command-ro-commandType>commandType</a>;          
+  readonly attribute DOMString <a href="#commandtype" title=dom-command-ro-commandType>commandType</a>;
   readonly attribute DOMString <a href="#id2" title=dom-command-ro-id>id</a>;
   readonly attribute DOMString <a href="#label3" title=dom-command-ro-label>label</a>;
   readonly attribute DOMString <a href="#title7" title=dom-command-ro-title>title</a>;
   readonly attribute DOMString <a href="#icon2" title=dom-command-ro-icon>icon</a>;
   readonly attribute boolean <a href="#hidden2" title=dom-command-ro-hidden>hidden</a>;
-  readonly attribute boolean <a href="#disabled7" title=dom-command-ro-disabled>disabled</a>;              
-  readonly attribute boolean <a href="#checked3" title=dom-command-ro-checked>checked</a>;              
+  readonly attribute boolean <a href="#disabled7" title=dom-command-ro-disabled>disabled</a>;
+  readonly attribute boolean <a href="#checked3" title=dom-command-ro-checked>checked</a>;
   void <a href="#click1" title=dom-command-ro-click>click</a>();
   readonly attribute <a href="#htmlcollection0">HTMLCollection</a> <a href="#triggers0" title=dom-command-ro-triggers>triggers</a>;
   readonly attribute <a href="#command0">Command</a> <span title=dom-command-ro-command>command</span>;
@@ -25921,7 +25921,7 @@ JSURI: http://ietfreport.isoc.org/all-ids/draft-hoehrmann-javascript-scheme-00.t
    title="">message</var>)</code></dfn> method, when invoked, must show the
    given <var title="">message</var> to the user, and ask the user to respond
    with a positive or negative response. The user agent must then <a
-   href="#pause">pause</a> as the the method waits for the user's response.
+   href="#pause">pause</a> as the method waits for the user's response.
    If the user responds positively, the method must return true, and if the
    user responds negatively, the method must return false.
 
@@ -25929,7 +25929,7 @@ JSURI: http://ietfreport.isoc.org/all-ids/draft-hoehrmann-javascript-scheme-00.t
    title="">message</var>, <var title="">default</var>)</code></dfn> method,
    when invoked, must show the given <var title="">message</var> to the user,
    and ask the user to either respond with a string value or abort. The user
-   agent must then <a href="#pause">pause</a> as the the method waits for the
+   agent must then <a href="#pause">pause</a> as the method waits for the
    user's response. The second argument is optional. If the second argument
    (<var title="">default</var>) is present, then the response must be
    defaulted to the value given by <var title="">default</var>. If the user
@@ -26050,7 +26050,7 @@ JSURI: http://ietfreport.isoc.org/all-ids/draft-hoehrmann-javascript-scheme-00.t
      (_), U+0061 (a) to U+007A (z), and U+007E (~).</p>
     <!-- XXX move that to a common algorithms section if any other
     part of the spec needs it -->
-    
+
     <div class=example>
      <p>If the user had visited a site that made the following call:</p>
 
@@ -28759,7 +28759,7 @@ user reload must be equivalent to .reload()
    ifragment? XXX -->
 
    <li>
-    <p>If <i>fragid</i> is the empty string, then the the indicated part of
+    <p>If <i>fragid</i> is the empty string, then the indicated part of
      the document is the top of the document.
 
    <li>
@@ -28854,11 +28854,11 @@ user reload must be equivalent to .reload()
    documents about once for every 5000 pages labelled "text/html", and
    "application/unknown" was used about once for every 35000 pages
    labelled "text/html". -->
-    
+
 
    <li>
     <p>If <var title="">official type</var> ends in "+xml", or if it is
-     either "text/xml" or "application/xml", then the the sniffed type of the
+     either "text/xml" or "application/xml", then the sniffed type of the
      resource is <var title="">official type</var>; return that and abort
      these steps.
    </li>
@@ -28923,7 +28923,7 @@ user reload must be equivalent to .reload()
        <td>FF FE 00 00
        <td>UTF-32LE BOM
 -->
-        
+
 
       <tr>
        <td>EF BB BF
@@ -28935,7 +28935,7 @@ user reload must be equivalent to .reload()
        <td>DD 73 66 73
        <td>UTF-EBCDIC BOM
 -->
-        
+
     </table>
 
     <p>...then the sniffed type of the resource is "text/plain".
@@ -28952,7 +28952,7 @@ user reload must be equivalent to .reload()
     for TAB, LF, VT, FF, and CR), and character 0x1B (reportedly used
     by some encodings as a shift escape), are invalid. Thus, if we see
     them, we assume it's not text. -->
-    
+
     <ul class=brief>
      <li> 0x00 - 0x08
 
@@ -29118,7 +29118,7 @@ user reload must be equivalent to .reload()
 
      <td>The string "<code title="">&lt;HTML</code>" in US-ASCII or
       compatible encodings, case-insensitively, possibly with leading spaces.
-      
+
 
     <tr>
      <td>FF FF DF DF DF DF
@@ -29130,7 +29130,7 @@ user reload must be equivalent to .reload()
 
      <td>The string "<code title="">&lt;HEAD</code>" in US-ASCII or
       compatible encodings, case-insensitively, possibly with leading spaces.
-      
+
 
     <tr>
      <td>FF FF DF DF DF DF DF DF
@@ -29142,14 +29142,14 @@ user reload must be equivalent to .reload()
 
      <td>The string "<code title="">&lt;SCRIPT</code>" in US-ASCII or
       compatible encodings, case-insensitively, possibly with leading spaces.
-      
+
 
     <tr>
      <td>FF FF FF FF FF
 
      <td>25 50 44 46 2D
       <!-- "%PDF-" (from http://lxr.mozilla.org/seamonkey/source/netwerk/streamconv/converters/nsUnknownDecoder.cpp#321) -->
-      
+
 
      <td>application/pdf
 
@@ -29160,7 +29160,7 @@ user reload must be equivalent to .reload()
 
      <td>25 21 50 53 2D 41 64 6F 62 65 2D
       <!-- "%!PS-Adobe-" (from http://lxr.mozilla.org/seamonkey/source/netwerk/streamconv/converters/nsUnknownDecoder.cpp#321) -->
-      
+
 
      <td>application/postscript
 
@@ -29370,7 +29370,7 @@ user reload must be equivalent to .reload()
     subsets of quoted ">" characters. If this fails, then that's ok,
     we'll treat it as HTML which is fine since we know it's not a feed
     in that case. -->
-    
+
     <ol>
      <li>Increase <var title="">pos</var> by 1.
 
@@ -29979,7 +29979,7 @@ interface <dfn id=storage0>Storage</dfn> {
     <!-- XXX should there be an explicit way for sites to state when
     data should expire? as in
     globalStorage.expireData(365); ? -->
-    
+
 
    <li>
     <p>Treating persistent storage as cookies: user agents may present the
@@ -30747,7 +30747,7 @@ interface <dfn id=sqlstatementerrorcallback>SQLStatementErrorCallback</dfn> {
    href="#navigate">navigate</a> a <a href="#browsing0">browsing context</a>
    to the URI of the hyperlink.
 
-  <p>The URI of the hyperlink is URI given by resolving the the <code
+  <p>The URI of the hyperlink is URI given by resolving the <code
    title=attr-hyperlink-href><a href="#href6">href</a></code> attribute of
    that hyperlink relative to the hyperlink's element. In the case of
    server-side image maps, the URI of the hyperlink must further have its
@@ -31170,13 +31170,13 @@ interface <dfn id=sqlstatementerrorcallback>SQLStatementErrorCallback</dfn> {
    do something about http://microformats.org/wiki/rel-enclosure
 
 mpt says:
-> "As with <a> elements, when <link> elements that use these relationships    
+> "As with <a> elements, when <link> elements that use these relationships
 > are present, UAs should render them. As with <a> elements, when <link>
 > elements that use these relationships do not exist, UAs should not
 > render them. UAs should not make <link> rendering any easier to hide
 > than <a> rendering."
-  
-for microformats (e.g. to refer to an hcard from an hcalendar):         
+
+for microformats (e.g. to refer to an hcard from an hcalendar):
 rel=xref
 <a> and <area> only
 The href attribute's value must start with a '#' character.
@@ -32000,7 +32000,7 @@ at the first element with the given ID must be treated as if it was cloned and r
    <tbody>
     <tr>
      <td><dfn id=protocol0 title=dom-uda-protocol><code>protocol</code></dfn>
-      
+
 
      <td>&lt;scheme&gt;
 
@@ -32033,7 +32033,7 @@ at the first element with the given ID must be treated as if it was cloned and r
 
     <tr>
      <td><dfn id=hostname0 title=dom-uda-hostname><code>hostname</code></dfn>
-      
+
 
      <td>&lt;host&gt;/&lt;ihost&gt;
 
@@ -32068,7 +32068,7 @@ at the first element with the given ID must be treated as if it was cloned and r
 
     <tr>
      <td><dfn id=pathname0 title=dom-uda-pathname><code>pathname</code></dfn>
-      
+
 
      <td>&lt;abs_path&gt;
 
@@ -34769,7 +34769,7 @@ Test:&nbsp;Line 2</pre>
      the events specified by DOM3 Events in <a
      href="http://www.w3.org/TR/DOM-Level-3-Events/events.html#Events-EventTypes-complete">section
      1.4.2 "Complete list of event types"</a>, then the event must bubble if
-     the DOM3 Events spec specifies that that event bubbles, and musn't
+     the DOM3 Events spec specifies that that event bubbles, and mustn't
      bubble if it specifies it does not. <a
      href="#refsDOM3EVENTS">[DOM3EVENTS]</a></p>
 
@@ -36857,13 +36857,13 @@ function receiver(e) {
        <td>DD 73 66 73
        <td>UTF-EBCDIC
 -->
-        
+
     </table>
 
    <li>
     <p>Otherwise, the user agent will have to search for explicit character
      encoding information in the file itself. This should proceed as follows:
-     
+
 
     <p>Let <var title="">position</var> be a pointer to a byte in the input
      stream, initially pointing at the first byte. If at any point during
@@ -37449,7 +37449,7 @@ function receiver(e) {
       that there are enough characters, since you can only run into
       this if the flag is true in the first place, which requires four
       characters. -->
-      
+
       <p>In any case, emit the input character as a character token. Stay in
        the <a href="#data-state">data state</a>.</p>
 
@@ -39312,7 +39312,7 @@ function receiver(e) {
 
      <li> The system identifier is set to: "<code
       title="">http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd</code>"
-      
+
 
      <li> The system identifier is missing and the public identifier is set
       to: "<code title="">-//W3C//DTD HTML 4.01 Frameset//EN</code>"
@@ -40575,7 +40575,7 @@ simplified explanation instead:
         <p class=big-issue>This doesn't match browsers.</p>
         <!-- XXX <p><i><p>: http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%3Cp%3E%3Ci%3E%3Cp%3E%3C%2Fp%3E%3C%2Fi%3E%3C%2Fp%3E -->
         <!-- XXX <p><i><div><p>: http://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%3Cp%3E%3Ci%3E%3Cdiv%3E%3Cp%3E%3C%2Fp%3E%3C%2Fdiv%3E%3C%2Fi%3E%3C%2Fp%3E -->
-        
+
         <p>If the <a href="#stack">stack of open elements</a> <a
          href="#have-an" title="has an element in scope">has a <code>p</code>
          element in scope</a>, then act as if an end tag with the tag name
@@ -40759,7 +40759,7 @@ simplified explanation instead:
         <p>Otherwise, act as if a start tag with the tag name given in
         the token had been seen, then reprocess the current token.</p>
         -->
-        
+
 
        <dt>An end tag whose tag name is "form"
 
@@ -40839,7 +40839,7 @@ simplified explanation instead:
         stack until an element with one of those tag names has been
         popped from the stack.</p>
         -->
-        
+
         <p><a href="#insert" title="insert an html element">Insert an HTML
          element</a> for the token.</p>
 
@@ -41086,7 +41086,7 @@ simplified explanation instead:
          <p class="big-issue">Need an example.</p>
         </div>
 -->
-        
+
         <p class=note>Because of the way this algorithm causes elements to
          change parents, it has been dubbed the "adoption agency algorithm"
          (in contrast with other possibly algorithms for dealing with
@@ -41199,7 +41199,7 @@ simplified explanation instead:
         <!-- As of
         2005-12, studies showed that around 0.2% of pages used the
         <image> element. -->
-        
+
 
        <dt>A start tag whose tag name is "input"
 
@@ -41390,12 +41390,12 @@ simplified explanation instead:
          href="#phrasing1">phrasing</a> element.</p>
         <!--
 Put the following into the MathML namespace if parsed:
-   math, mrow, mfrac, msqrt, mroot, mstyle, merror, mpadded, 
-   mphantom, mfenced, menclose, msub, msup, msubsup, munder, 
-   mover, munderover, mmultiscripts, mtable, mlabeledtr, mtr, 
+   math, mrow, mfrac, msqrt, mroot, mstyle, merror, mpadded,
+   mphantom, mfenced, menclose, msub, msup, msubsup, munder,
+   mover, munderover, mmultiscripts, mtable, mlabeledtr, mtr,
    mtd, maction
 -->
-        
+
 
        <dt>An end tag token not covered by the previous entries
 
@@ -42312,7 +42312,7 @@ Put the following into the MathML namespace if parsed:
     into it, otherwise (e.g. if there was a <frameset>) it'll go into
     the <html> node (this is important in case we have "foo</html>
     bar", as we don't want that to become one word) -->
-    
+
 
    <dt>A character token that is <em>not</em> one of U+0009 CHARACTER
     TABULATION, U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM
@@ -42392,19 +42392,19 @@ see also  CTextToken::ConsumeCharacterData()  for CDATA parsing?
 1212                      1  Here's a tricky case from bug 22596:  <h5><li><h5>
 1213                         How do we know that the 2nd <h5> should close the <LI> rather than nest inside the <LI>?
 1214                         (Afterall, the <h5> is a legal child of the <LI>).
-1215               
+1215
 1216                         The way you know is that there is no root between the two, so the <h5> binds more
 1217                         tightly to the 1st <h5> than to the <LI>.
 1218                      2.  Also, bug 6148 shows this case: <SPAN><DIV><SPAN>
 1219                         From this case we learned not to execute this logic if the parent is a block.
-1220                     
+1220
 1221                      3. Fix for 26583
 1222                         Ex. <A href=foo.html><B>foo<A href-bar.html>bar</A></B></A>  <- A legal HTML
 1223                         In the above example clicking on "foo" or "bar" should link to
 1224                         foo.html or bar.html respectively. That is, the inner <A> should be informed
 1225                         about the presence of an open <A> above <B>..so that the inner <A> can close out
 1226                         the outer <A>. The following code does it for us.
-1227                      
+1227
 1228                      4. Fix for 27865 [ similer to 22596 ]. Ex: <DL><DD><LI>one<DD><LI>two
  - http://lxr.mozilla.org/mozilla/source/parser/htmlparser/src/CNavDTD.cpp#1211
 
@@ -42544,7 +42544,7 @@ http://lxr.mozilla.org/seamonkey/search?string=nested
       <!-- note about noscript: we're
       assuming here that scripting is disabled. If this algorithm is
       used with scripting disabled, this won't work right. -->
-      
+
       <p>Otherwise, append the value of the <var title="">child</var> node's
        <code title="">data</code> DOM attribute, <a href="#escapingString"
        title="escaping a string">escaped as described below</a>.</p>
@@ -45035,8 +45035,8 @@ Application object? http://longhorn.msdn.microsoft.com/lhsdk/ref/ns/msavalon.win
 window.open for dialogs
 
 
-Thus, they lack things like proper windows, tree 
-widgets, menu bars, rich text areas and so forth. This is what I would 
+Thus, they lack things like proper windows, tree
+widgets, menu bars, rich text areas and so forth. This is what I would
 like XUL to solve. - Paul Prescod
 
 
@@ -45061,12 +45061,12 @@ http://mail.mozilla.org/private/gui-toolkit/2004-April/000041.html
 > > > A standard for rich edit widgets would also be of interest to me.
 > >
 > > As in WYSIWIG editing? Of the bold/italic/underline/larger/smaller kind?
-> > 
+> >
 > > Or do you mean as in the bare bones to be able to build an editor on top
 > > of? As in something that basically just gives you a cursor and the ability
 > > to tell where the selection is and some way to hook into the Undo
 > > functionality?
-> 
+>
 > I have use cases for both...I have a more desperate business need for
 > the latter (and have build apps using the gross APIs out there today)
 > but there are a lot of circumstances where an editor that already has
@@ -45174,15 +45174,15 @@ Wladimir Palant pointed out problems with chunking with server-sent-events
   ::                                                       ::
   ::  The Web page at this domain:                         ::
   ::                                                       ':
-  ::     paypcl.com                                        
-  ::                                                       
-  ::  ...wishes to launch an application in a separate     
-  ::  window. Do you trust this domain?                    
-  ::                                                       
-  ::  [x] Remember this decision.                          
-  ::                                                       
-  ::      (( Trust paypcl.com ))  ( Display as Web page )  
-  ::                                                      
+  ::     paypcl.com
+  ::
+  ::  ...wishes to launch an application in a separate
+  ::  window. Do you trust this domain?
+  ::
+  ::  [x] Remember this decision.
+  ::
+  ::      (( Trust paypcl.com ))  ( Display as Web page )
+  ::
   :::::.
 - (spurred on by Jose Dinuncio)
 
@@ -45193,13 +45193,13 @@ Wladimir Palant pointed out problems with chunking with server-sent-events
   ::  separate window. Do you trust this domain?           ::
   ::                                                       ::
   ::     paypcl.com                                         '
-  ::                                                       
+  ::
   ::             ( Trust this site for now )
   ::
   ::              ( Always trust this site )
   ::
   ::              (( Display as Web page ))
-  ::                                                      
+  ::
   :::::.
 
 
@@ -45230,7 +45230,7 @@ http://www.activewidgets.com/grid/
 >
 > In that way the dom level 2 traversal and range specification would not
 > be useless for textarea's.
-> 
+>
 > The same goes for input text controls and probably also for other form
 > controls.
  - martijnw
@@ -45309,7 +45309,7 @@ http://www.activewidgets.com/grid/
       </cat:BasePrice>
     </cat:Item>
   </cat:OrderLine>
-</Order> 
+</Order>
 
 </instance>
 
@@ -45335,13 +45335,13 @@ http://www.activewidgets.com/grid/
 Disclosure triangles
 
 
-I think UAs should automatically highlight the accesskey (or add it in    
+I think UAs should automatically highlight the accesskey (or add it in
 brackets if it isn't already in the string). I am thinking of writing some
-text - optional, of course, since this wouldn't apply to all UAs or all  
+text - optional, of course, since this wouldn't apply to all UAs or all
 platforms - that specifies this.
 
-I also think that there should be an accesskey value which is basically   
-"auto", and which picks a non-clashing access key based on the element    
+I also think that there should be an accesskey value which is basically
+"auto", and which picks a non-clashing access key based on the element
 content.
 
 
@@ -45352,19 +45352,19 @@ content.
 |   - add user data to a site's authentication state in the browser
 |     (i.e., "log on" interfaces)
 |   - display the user's current authentication state
-| 
+|
 | There are a few good reasons to do this. Many sites use cookies to
 | authenticate users, because HTTP authentication doesn't have any
 | mechanism to allow logging out (a key requirement of financial
 | institutions and other sensitive applications), and because the UI for
 | HTTP authentication can't be controlled, and doesn't offer an
 | "anyonymous" / "not logged in" view.
-| 
+|
 | By accommodating HTTP authentication in Web forms, it will be possible
 | to have styled, custom "log on" interfaces as part of pages, as well
 | as "log out" facilities, while still retaining the benefits of HTTP
 | authentication.
-| 
+|
 | Specifically, HTTP authentication is more secure than cookies (when
 | Digest auth is used), and is more amenable to automated processes
 | (agents, spiders, etc.) as well as alternate browsing devices (screen
@@ -45378,8 +45378,8 @@ Yeah, <header> and <footer> or similar elements are almost certainly going
 to be defined at some point, along with <content> (for the main body of
 the page), <entry> or <post> or <article> to refer to a unit of text
 bigger than a section but smaller than a page, <aside> to mean a
-side bar, <note> to mean a note... and so forth. Suggestions welcome.     
-We'll probably keep it to a minimum though. The idea is just to relieve   
+side bar, <note> to mean a note... and so forth. Suggestions welcome.
+We'll probably keep it to a minimum though. The idea is just to relieve
 the most common pseudo-semantic uses of <div>.
 
 
@@ -45429,7 +45429,7 @@ message if there is a return value, and calling preventDefault if
 there isn't.
 
 
-> > > Schematic editors, layout editors, interactive maps, data 
+> > > Schematic editors, layout editors, interactive maps, data
 > > > visualization for network flows, etc.
 > Searching the web for the above keywords should find you a lot more.
  - Denis Bohm
@@ -45466,7 +45466,7 @@ In other areas, however, the replacement is not a match in terms of functionalit
 >    HTML editing: Editing Tables
 >    Input type=file improvements
 >    .NET framework
->    
+>
 > http://channel9.msdn.com/wiki/default.aspx/Channel9.InternetExplorerOutrageous
 >     Some decent controls
  - lachlan.hunt@lachy.id.au
@@ -45478,18 +45478,18 @@ http://lists.w3.org/Archives/Member/w3c-html-wg/2004JulSep/att-0135/role072704a.
 > I've encountered two situations where setting or retrieving the caret
 > position would be useful.  The first is a situation where I'd like to
 > apply an input mask to a text box.  For example, I'd like the ability to
-> create a text box where the date delimiters (dashes or slashes) appear  
-> automatically in a text box upon entering the field, and when the user  
-> types in the field, it fills into the appropriate spaces in the input    
-> box and sets the text selection to the next appropriate position, all    
-> while allowing the user to reposition the cursor within the text box     
+> create a text box where the date delimiters (dashes or slashes) appear
+> automatically in a text box upon entering the field, and when the user
+> types in the field, it fills into the appropriate spaces in the input
+> box and sets the text selection to the next appropriate position, all
+> while allowing the user to reposition the cursor within the text box
 > with a keyboard or mouse without being able to edit or delete the
 > delimiters (dashes or slashes).  This would be very similar to input
 > mask features in certain native apps that I've used.
  - Greg Kilwein
 
-> The second situation is an application that would like to highlight text  
-> in a text box or textarea for the purposes of a spell check, thesaurus, 
+> The second situation is an application that would like to highlight text
+> in a text box or textarea for the purposes of a spell check, thesaurus,
 > or search-and-replace operation.
  - Greg Kilwein
 
@@ -45617,11 +45617,11 @@ of alternate style sheet processing
 > (if available) in the same consistent position in a search result, and
 > the name of the author (if available) in the same consistent position in
 > a search result.
->  
+>
 > For that to happen, it would help slightly if the HTML specification
 > stopped SHOULD-ing the current <title> behavior. It would help more if
 > the HTML specification contained clear, straightforward markup for
-> author and site name (and encouraged UAs to present this information   
+> author and site name (and encouraged UAs to present this information
 > when the document is taken out of context).
 
    <title site="" publisher="" author="">Page Title</title>
@@ -45754,7 +45754,7 @@ http://www.microsoft.com/mind/1097/directanim.asp
 
 events: onmousewheel
 <hyatt> with a wheelDelta field on the WheelEvent (whcih comes off UIEvent)
-<hyatt> but in OS X you can wheel horizontally 
+<hyatt> but in OS X you can wheel horizontally
 <hyatt> so we actually added wheelX, wheelY, and wheelZ
 <hyatt> with wheelDelta just mapping to wheelY for WinIE compat
 <Hixie_> oh i don't mind wheelZ, maybe we can even say ctrl+wheel should map to it on some platforms (windows)
@@ -45799,7 +45799,7 @@ http://www.paulgraham.com/popular.html
   index.</p>
 
 
-"you have mail": bubble notification; flash taskbar button, 
+"you have mail": bubble notification; flash taskbar button,
 => how do you stop advertisers?
 
 
@@ -45836,7 +45836,7 @@ one of the following are true:
  4. The element is a transparent IFRAME (in IE, an IFRAME with the
     custom attribute "allowtransparency");
 
- 5. The element is an OBJECT with the custom attribute "wmode" set to 
+ 5. The element is an OBJECT with the custom attribute "wmode" set to
     "transparent" and the point in question is fully transparent.
 
 Given those definitions, when a mouse event occurs, IE finds the
@@ -45979,7 +45979,7 @@ XXX "alternate style sheet" should be "alternative style sheet"
   element must be disabled. The <code>button</code> element must also
   be disabled if the element's <code>disabled</code> attribute is
   set.</p>
- 
+
   <p>The Label, Icon, Checked State and Type facets of the command are
   ignored by the <code>button</code> element (except for <a
   href="#pseudosAndCommands">matching CSS pseudo-classes</a>).</p>

--- a/src/nu/validator/gnu/xml/aelfred2/package.html
+++ b/src/nu/validator/gnu/xml/aelfred2/package.html
@@ -13,7 +13,7 @@
 
 <p> This package contains &AElig;lfred2, which includes an
 enhanced SAX2-compatible version of the &AElig;lfred
-non-validating XML parser, a modular (and hence optional) 
+non-validating XML parser, a modular (and hence optional)
 DTD validating parser, and modular (and hence optional)
 JAXP glue to those.
 Use these like any other SAX2 parsers. </p>
@@ -108,7 +108,7 @@ removed, and so the overall size of &AElig;lfred was actually reduced.
 Subsequent performance work produced a notable speedup (over twenty
 percent on larger files).  That is, the tradeoffs between speed, size, and
 conformance were re-targeted towards conformance and support of newer APIs
-(SAX2), with a a positive performance impact. </p>
+(SAX2), with a positive performance impact. </p>
 
 <p> The role anticipated for this version of &AElig;lfred is as a
 lightweight Free Software SAX parser that can be used in essentially every
@@ -169,7 +169,7 @@ all XML parsers are required to support:</p> <ul>
     in anticipation that Unicode (even with surrogate pairs)
     would eventually become limiting.  UCS-4 permits encoding
     of non-Unicode characters, which Java can't represent (and
-    XML doesn't allow).  
+    XML doesn't allow).
     </li>
 
     </ul>
@@ -205,9 +205,9 @@ Of course, UTF-8 and UTF-16 handle the Euro symbol directly.
 
 <h3><a name="violations">Known Conformance Violations</a></h3>
 
-<p>Known conformance issues should be of negligible importance for 
+<p>Known conformance issues should be of negligible importance for
 most applications, and include: </p><ul>
-    
+
     <li> Rather than following the voluminous "Appendix B" rules about
     what characters may appear in names (and name tokens), the Unicode
     rules embedded in <em>java.lang.Character</em> are used.
@@ -285,7 +285,7 @@ refocusing the API on SAX2, and improving conformance to the extent
 that most developers should not need to use another XML parser.  </p>
 
 <p> The code has been cleaned up (referring to the XML 1.0 spec in
-all the production numbers in 
+all the production numbers in
 comments, rather than some preliminary draft, for one example) and
 has been sped up a bit as well.
 JAXP support has been added, although developers are still
@@ -471,4 +471,3 @@ constraints that can't be verified using the SAX2 event stream
 are now reported directly by &AElig;lfred2. </p>
 
 </body></html>
-


### PR DESCRIPTION
Fixed various formatting inconsistencies, such as unnecessary whitespace, and corrected repeated words like "the the." […]

(This commit message was AI-generated.)