### PR TITLE
In `build.py`, parse only the line matching "version"

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -1774,9 +1774,9 @@ def main(argv):
         except TypeError:
             javaRawVersion = subprocess.check_output([javaCmd, '-version'],
                                                      stderr=subprocess.STDOUT)
+        javaRawVersion = list(filter(lambda x:'version' in x, javaRawVersion.splitlines()))
         javaEnvVersion = \
-            int(javaRawVersion
-                .splitlines()[0].split()[2].strip('"').split('.')[0]
+            int(javaRawVersion[0].split()[2].strip('"').split('.')[0]
                 .replace('-ea', ''))
         if javaEnvVersion < 9:
             javaTargetVersion = ''


### PR DESCRIPTION
When we use _JAVA_OPTIONS, the 1st line is not the version but a message saying what value is taken from _JAVA_OPTIONS.

Because of this, build.py fails.

Make sure to parse only the line that has the word "version"