### PR TITLE
Simplify way to get ImplementationVersion

### DIFF
--- a/src/nu/validator/client/SimpleCommandLineValidator.java
+++ b/src/nu/validator/client/SimpleCommandLineValidator.java
@@ -120,16 +120,7 @@ public class SimpleCommandLineValidator {
     private static boolean hasSchemaOption;
 
     public static void main(String[] args) throws SAXException, Exception {
-        Enumeration<URL> resources = SimpleCommandLineValidator.class. //
-                getClassLoader().getResources("META-INF/MANIFEST.MF");
-        while (resources.hasMoreElements()) {
-            try (InputStream is = resources.nextElement().openStream()) {
-                version = new Manifest(is).getMainAttributes() //
-                        .getValue("Implementation-Version");
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
+        version = SimpleCommandLineValidator.class.getPackage().getImplementationVersion();
         out = System.err;
         otherOut = System.out;
         userAgent = "Validator.nu/LV";


### PR DESCRIPTION
While trying to create a Debian package for vnu for most dependencies I use the jars shipped by Debian. So I updated the build script to set the Class-Path in the Manifest.

However, this results in wrong or undefined value of the version. Apparently, when the Class-Path of the manifest references multiple jars, version will be updated by each iteration on the packages in the classpath, and the version results in being incorrect or unset.

This change will simplify the query and ensures that we get the version of the current package, without iterating over every dependency.