### PR TITLE
feat: add support for `popover*` attributes

### DIFF
--- a/schema/html5/applications.rnc
+++ b/schema/html5/applications.rnc
@@ -10,6 +10,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		(	common.attrs.contenteditable?
 		&	common.attrs.draggable?
 		&	common.attrs.hidden?
+		&	common.attrs.popover?
 		)
 		
 	common.attrs.other &= common.attrs.interact
@@ -33,6 +34,13 @@ datatypes w = "http://whattf.org/datatype-draft"
 	common.attrs.hidden =
 		attribute hidden {
 			w:string "hidden" | w:string "until-found" | w:string ""
+		}
+
+## Popover Element: popover
+
+	common.attrs.popover =
+		attribute popover {
+			w:string "auto" | w:string "manual" | w:string "hint" | w:string ""
 		}
 
 ## Global attributes applicable on elements with editable content

--- a/schema/html5/embed.rnc
+++ b/schema/html5/embed.rnc
@@ -224,6 +224,7 @@ namespace local = ""
 			                    | contenteditable
 			                    | draggable
 			                    | hidden
+			                    | popover
 			                    | inputmode
 			                    | nonce
 			                    | onauxclick

--- a/schema/html5/web-forms.rnc
+++ b/schema/html5/web-forms.rnc
@@ -163,6 +163,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	common-form.attrs
 		&	input.button.attrs.type
 		&	input.button.attrs.value? 
+		&	button.attrs.popover-controls
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
 			|	common.attrs.aria.role.checkbox
@@ -198,6 +199,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	common-form.attrs
 		&	input.submit.attrs.type
 		&	input.submit.attrs.value? 
+		&	button.attrs.popover-controls
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
 			)?
@@ -222,6 +224,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	common-form.attrs
 		&	input.reset.attrs.type
 		&	input.reset.attrs.value? 
+		&	button.attrs.popover-controls
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
 			)?
@@ -290,6 +293,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	input.image.attrs.type
 		&	input.image.attrs.alt 
 		&	input.image.attrs.src? 
+		&	button.attrs.popover-controls
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
 			|	common.attrs.aria.role.link
@@ -444,6 +448,18 @@ datatypes w = "http://whattf.org/datatype-draft"
 		attribute value {
 			string
 		}
+	button.attrs.popover-controls =
+		(	button.attrs.popovertarget?
+		&	button.attrs.popovertargetaction?
+		)
+	button.attrs.popovertarget =
+		attribute popovertarget {
+			common.data.idref
+		}
+	button.attrs.popovertargetaction =
+		attribute popovertargetaction {
+			w:string "hide" | w:string "show" | w:string "toggle"
+		}
 	button.inner = 
 		( common.inner.phrasing )
 	
@@ -456,6 +472,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	common-form.attrs
 		&	button.submit.attrs.type?
 		&	button.attrs.value?
+		&	button.attrs.popover-controls
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
 			|	common.attrs.aria.role.checkbox
@@ -485,6 +502,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	common-form.attrs
 		&	button.reset.attrs.type
 		&	button.attrs.value? #REVISIT I guess this still affects the DOM
+		&	button.attrs.popover-controls
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
 			|	common.attrs.aria.role.checkbox
@@ -513,6 +531,7 @@ datatypes w = "http://whattf.org/datatype-draft"
 		&	common-form.attrs
 		&	button.button.attrs.type
 		&	button.attrs.value? #REVISIT I guess this still affects the DOM
+		&	button.attrs.popover-controls
 		&	(	common.attrs.aria.implicit.button
 			|	common.attrs.aria.role.button
 			|	common.attrs.aria.role.checkbox


### PR DESCRIPTION
Added the `popover`, `popovertarget`, and `popovertargetaction` attributes.

Tests: https://github.com/validator/tests/pull/5

Connected to #1818 and #1534.