### PR TITLE
Make order of command-line options consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ Run the checker with one of the following invocations:
 …where _`FILES`_ are the documents to check, and _`OPTIONS`_ are zero or more of
 the following options:
 
-    --errors-only --Werror --exit-zero-always --stdout --asciiquotes
-    --user-agent USER_AGENT --no-langdetect --no-stream --filterfile FILENAME
-    --filterpattern PATTERN --css --skip-non-css --also-check-css --svg
-    --skip-non-svg --also-check-svg --xml --html --skip-non-html
-    --format gnu|xml|json|text --help --verbose --version
+    --asciiquotes --errors-only --Werror --exit-zero-always --stdout
+    --filterfile FILENAME --filterpattern PATTERN --format gnu|xml|json|text
+    --help --skip-non-css --css --skip-non-svg --svg --skip-non-html --html
+    --xml --also-check-css --also-check-svg --user-agent USER_AGENT
+    --no-langdetect --no-stream --verbose --version --entities --schema SCHEMA
 
 The [Options][27] section below provides details on each option, and the rest of
 this section provides some specific examples.

--- a/src/nu/validator/client/SimpleCommandLineValidator.java
+++ b/src/nu/validator/client/SimpleCommandLineValidator.java
@@ -165,8 +165,8 @@ public class SimpleCommandLineValidator {
                 fileArgsStart = i;
                 break;
             } else {
-                if ("--verbose".equals(args[i])) {
-                    verbose = true;
+                 else if ("--asciiquotes".equals(args[i])) {
+                    asciiQuotes = true;
                 } else if ("--errors-only".equals(args[i])) {
                     errorsOnly = true;
                     System.setProperty("nu.validator.datatype.warn", "false");
@@ -177,8 +177,6 @@ public class SimpleCommandLineValidator {
                 } else if ("--stdout".equals(args[i])) {
                     out = System.out;
                     otherOut = System.err;
-                } else if ("--asciiquotes".equals(args[i])) {
-                    asciiQuotes = true;
                 } else if ("--filterfile".equals(args[i])) {
                     File filterFile = new File(args[++i]);
                     StringBuilder sb = new StringBuilder();
@@ -218,26 +216,13 @@ public class SimpleCommandLineValidator {
                     }
                 } else if ("--format".equals(args[i])) {
                     outFormat = args[++i];
-                } else if ("--user-agent".equals(args[i])) {
-                    userAgent = args[++i];
-                } else if ("--version".equals(args[i])) {
-                    if (version != null) {
-                        otherOut.println(version);
-                    } else {
-                        otherOut.println("[unknown version]");
-                    }
-                    System.exit(0);
                 } else if ("--help".equals(args[i])) {
                     help();
                     System.exit(0);
-                } else if ("--also-check-css".equals(args[i])) {
-                    alsoCheckCSS = true;
                 } else if ("--skip-non-css".equals(args[i])) {
                     skipNonCSS = true;
                 } else if ("--css".equals(args[i])) {
                     forceCSS = true;
-                } else if ("--also-check-svg".equals(args[i])) {
-                    alsoCheckSVG = true;
                 } else if ("--skip-non-svg".equals(args[i])) {
                     skipNonSVG = true;
                 } else if ("--svg".equals(args[i])) {
@@ -248,12 +233,27 @@ public class SimpleCommandLineValidator {
                     forceHTML = true;
                 } else if ("--xml".equals(args[i])) {
                     forceXML = true;
-                } else if ("--entities".equals(args[i])) {
-                    loadEntities = true;
+                } else if ("--also-check-css".equals(args[i])) {
+                    alsoCheckCSS = true;
+                } else if ("--also-check-svg".equals(args[i])) {
+                    alsoCheckSVG = true;
+                } else if ("--user-agent".equals(args[i])) {
+                    userAgent = args[++i];
                 } else if ("--no-langdetect".equals(args[i])) {
                     noLangDetect = true;
                 } else if ("--no-stream".equals(args[i])) {
                     noStream = true;
+                } else if ("--verbose".equals(args[i])) {
+                    verbose = true;
+                } else if ("--version".equals(args[i])) {
+                    if (version != null) {
+                        otherOut.println(version);
+                    } else {
+                        otherOut.println("[unknown version]");
+                    }
+                    System.exit(0);
+                } else if ("--entities".equals(args[i])) {
+                    loadEntities = true;
                 } else if ("--schema".equals(args[i])) {
                     hasSchemaOption = true;
                     schemaUrl = args[++i];


### PR DESCRIPTION
The command-line options were listed in three different orders.
This pull request makes all three lists consistent.
It does not change the [Options](https://validator.github.io/validator/#options) section of the documentation, but changes the other two lists to be consistent with it.
