### PR TITLE
TestRunner: write to the messagesFile only at the end.

### DIFF
--- a/src/nu/validator/client/TestRunner.java
+++ b/src/nu/validator/client/TestRunner.java
@@ -450,15 +450,6 @@ public class TestRunner extends MessageEmitterAdapter {
             validator.setUpValidatorAndParsers(this, false, false);
             checkHasWarningFiles(hasWarningFiles);
         }
-        if (writeMessages) {
-            OutputStreamWriter out = new OutputStreamWriter(
-                    new FileOutputStream(messagesFile), "utf-8");
-            try (BufferedWriter bw = new BufferedWriter(out)) {
-                JsonWriter jsonWriter = Json.createWriter(bw);
-                jsonWriter.writeObject(reportedMessages.build());
-                jsonWriter.close();
-            }
-        }
     }
 
     public boolean runTestSuite() throws SAXException, Exception {
@@ -481,6 +472,15 @@ public class TestRunner extends MessageEmitterAdapter {
                 } else {
                     checkTestDirectoryAgainstSchema(directory, schema);
                 }
+            }
+        }
+        if (writeMessages) {
+            OutputStreamWriter out = new OutputStreamWriter(
+                    new FileOutputStream(messagesFile), "utf-8");
+            try (BufferedWriter bw = new BufferedWriter(out)) {
+                JsonWriter jsonWriter = Json.createWriter(bw);
+                jsonWriter.writeObject(reportedMessages.build());
+                jsonWriter.close();
             }
         }
         if (verbose) {


### PR DESCRIPTION
Addition/Fix to ff0c83ed48ba45341f1db530542b525374b1519d

Since reportedMessages.build() flushes the content of the JsonObjectBuilder it has to be called only once, at the end of the processing.

After ff0c83ed48ba45341f1db530542b525374b1519d, the resulting `messages.json` became empty when running `make -C tests/ messages.json`. This should fix it.