### PR TITLE
Permit to load html5spec from file (optionally)

### DIFF
--- a/src/nu/validator/localentities/LocalCacheEntityResolver.java
+++ b/src/nu/validator/localentities/LocalCacheEntityResolver.java
@@ -1,6 +1,8 @@
 package nu.validator.localentities;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -44,10 +46,20 @@ public class LocalCacheEntityResolver implements EntityResolver {
         return LOADER.getResourceAsStream("nu/validator/localentities/files/presets");
     }
 
-    public static InputStream getHtml5SpecAsStream() {
-        return LOADER.getResourceAsStream("nu/validator/localentities/files/html5spec");
+    public static InputStream getHtml5SpecAsStream(String resourceName) {
+        return LOADER.getResourceAsStream(resourceName);
     }
     
+    public static InputStream getHtml5SpecAsStream(File file) {
+        try {
+            InputStream fis = new FileInputStream(file);
+            return fis;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
     private EntityResolver delegate;
 
     private boolean allowRnc = false;


### PR DESCRIPTION
Use case: when vnu is distributed in a distro (eg. Debian...), the version of vnu is fixed in a given release of the distro. Yet, the user may want to use vnu with a more recent html5spec copy that is located on his filesystem. It could for example be located in /var/lib/vnu/.

We could also imagine that the html5spec, which is an external resource to this project, is not distributed in the vnu package itself, but in another package. In such a setup, vnu could use the html5spec from that location more easily in place of the built-in html5spec. This could be configured through a /etc/vnu/vnu.properties file for example.

In this commit, the path to the html5spec is searched the vnu.properties file. Ideally, this would be searched in /etc/vnu/vnu.properties in case vnu is deployed on tomcat/jetty... The System property that was removed in 85cf3b13f143474c4db5a33905f64c46f4f27874 is now restored through a file.

Property name: nu.validator.spec.html5-load
Property value: path to the html5spec on the filesystem

Please think twice about it before merging.