### PR TITLE
docs: State that JDK 11+ is now required

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Along with using the [project issue tracker][1] you can get help in real time in
 Follow the steps below to build, test, and run the checker such that you can open
 http://localhost:8888/ in a Web browser to use the checker Web UI.
 
-1. Make sure you have git, python, and JDK 8 or later installed.
+1. Make sure you have git, python, and JDK 11 or later installed.
 
 2. Set the `JAVA_HOME` environment variable:
 
@@ -24,7 +24,7 @@ http://localhost:8888/ in a Web browser to use the checker Web UI.
 
    For example:
 
-   * `export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64` (newer Ubuntu)
+   * `export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64` (newer Ubuntu)
    * `export JAVA_HOME=$(/usr/libexec/java_home)` (Mac OS X)
 
 3. Create a working directory:

--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ To define a service named `vnu` for use with `docker compose`, create a Compose 
 
 Follow the steps below to build, test, and run the vnu checker such that you can open `http://0.0.0.0:8888/` in a Web browser to use the vnu checker Web UI.
 
-  1. Make sure you have git, python, JDK 8 or above and [ant](https://ant.apache.org/manual/install.html) installed.
+  1. Make sure you have git, python, JDK 11 or above and [ant](https://ant.apache.org/manual/install.html) installed.
 
   2. Set the `JAVA_HOME` environment variable:
 
-         export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64    <-- Ubuntu, etc.
+         export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
          export JAVA_HOME=$(/usr/libexec/java_home)            <-- macOS
 


### PR DESCRIPTION
Fixes https://github.com/validator/validator/issues/1857. @tenzap please take a look
