### PR TITLE
Add option to only show HTML errors and warnings

### DIFF
--- a/site/nu-style.css
+++ b/site/nu-style.css
@@ -895,7 +895,8 @@ dl.inputattrs .highlight {
 }
 
 #filters .hide,
-#filters .show {
+#filters .show,
+#filters .show-html {
 	color: #00f;
 }
 


### PR DESCRIPTION
Made a simple adjustment to allow to show and reproduce only HTML issues (available under “Message Filtering,” then “show only HTML errors” and “show only HTML warnings”).

@sideshowbarker, tried to test locally but seem to end up on an interface I’m not familiar with:

<img width="1271" height="837" alt="Screenshot of local validator." src="https://github.com/user-attachments/assets/1578cd10-a651-405d-bf72-8771875aee22">

Poked around but couldn’t get to the version providing message filtering. Can you advise or test on your end?

Resolves #940 