### PR TITLE
ci: use include for old Java Linux testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [25, 21, 17, 11.0.23]
-        exclude:
-          - os: macos-latest
-            java: 11.0.23
-          - os: windows-latest
-            java: 11.0.23
-          - os: macos-latest
+        java:
+          - 25
+        include:
+          - os: ubuntu-latest
+            java: 11
+          - os: ubuntu-latest
             java: 17
-          - os: windows-latest
-            java: 17
-          - os: macos-latest
+          - os: ubuntu-latest
             java: 21
-          - os: windows-latest
-            java: 21
+
     env:
       IS_MAIN_RELEASE_BUILDER: ${{ github.event_name == 'push' &&
                               github.ref == 'refs/heads/main' &&


### PR DESCRIPTION
Was looking at the pinned `11.0.23` and realized that the `exclude` could flip to an `include` since only the latest version is run on all OSs