### PR TITLE
ci: add Bazel Central Registry publish automation

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://validator.github.io/validator/",
+    "maintainers": [
+        {
+            "email": "robert@vantle.org",
+            "github": "robbie-vanderzee",
+            "github_user_id": 26888565,
+            "name": "Robbie VanDerzee"
+        }
+    ],
+    "repository": [
+        "github:validator/validator",
+        "https://registry.npmjs.org/vnu-jar/"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/overlay/BUILD.bazel
+++ b/.bcr/overlay/BUILD.bazel
@@ -1,0 +1,3 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["build/dist/vnu.jar"])

--- a/.bcr/overlay/MODULE.bazel
+++ b/.bcr/overlay/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "vnu",
+    version = "{VERSION}",
+    compatibility_level = 26,
+    bazel_compatibility = [">=9.0.0"],
+)

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify:
+    name: Verify vnu jar
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@vnu//:build/dist/vnu.jar'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-{VERSION}.tgz",
+    "integrity": "",
+    "strip_prefix": "package",
+    "overlay": {
+        "BUILD.bazel": "",
+        "MODULE.bazel": ""
+    }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish to BCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@main
+    with:
+      tag_name: ${{ inputs.tag_name || github.event.release.tag_name }}
+      registry_fork: robbie-vanderzee/bazel-central-registry
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.bcr/` configuration and GitHub Actions workflow for automated publishing to the [Bazel Central Registry](https://registry.bazel.build/) via [publish-to-bcr](https://github.com/bazel-contrib/publish-to-bcr).

- `.bcr/metadata.template.json` — maintainer and repository metadata
- `.bcr/source.template.json` — npm tarball URL template with `{VERSION}` substitution
- `.bcr/presubmit.yml` — CI matrix (debian11, ubuntu2004, macos, macos_arm64, windows × Bazel 7.x, 8.x, 9.x)
- `.bcr/overlay/` — BUILD.bazel and MODULE.bazel overlays
- `.github/workflows/publish.yml` — reusable workflow triggered on release or manual dispatch

### Setup required

Add a GitHub PAT with `repo` + `workflow` scopes as the `BCR_PUBLISH_TOKEN` repository secret.