### PR TITLE
Upgrade to jetty 12.0

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -127,7 +127,7 @@ DEALINGS IN THE SOFTWARE.
              classpath="${depsDir}/maven-ant-tasks-${maven-ant-tasks-version}.jar"/>
   </target>
 
-  <property name="jetty-version" value="11.0.20" />
+  <property name="jetty-version" value="12.0.34" />
   <target name="dl-deps-jetty" unless="${offline}">
     <echo>Downloading dependencies (jetty)</echo>
     <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-client/${jetty-version}/jetty-client-${jetty-version}.jar"/>
@@ -135,8 +135,9 @@ DEALINGS IN THE SOFTWARE.
     <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-io/${jetty-version}/jetty-io-${jetty-version}.jar"/>
     <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-security/${jetty-version}/jetty-security-${jetty-version}.jar"/>
     <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/${jetty-version}/jetty-server-${jetty-version}.jar"/>
-    <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-servlet/${jetty-version}/jetty-servlet-${jetty-version}.jar"/>
-    <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-servlets/${jetty-version}/jetty-servlets-${jetty-version}.jar"/>
+    <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/ee10/jetty-ee10-servlet/${jetty-version}/jetty-ee10-servlet-${jetty-version}.jar"/>
+    <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/ee10/jetty-ee10-servlets/${jetty-version}/jetty-ee10-servlets-${jetty-version}.jar"/>
+    <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-session/${jetty-version}/jetty-session-${jetty-version}.jar"/>
     <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/${jetty-version}/jetty-util-${jetty-version}.jar"/>
   </target>
 
@@ -146,7 +147,7 @@ DEALINGS IN THE SOFTWARE.
   <property name="commons-logging-version" value="1.2" />
   <property name="commons-text-version" value="1.12.0" />
   <property name="icu4j-version" value="75.1" />
-  <property name="jakarta.servlet-api-version" value="5.0.2" />
+  <property name="jakarta.servlet-api-version" value="6.1.0" />
   <property name="javax.json-version" value="1.1.4" />
   <property name="jchardet-version" value="1.0" />
   <property name="log4j-version" value="1.2.17" />
@@ -166,7 +167,7 @@ DEALINGS IN THE SOFTWARE.
     <get-and-checksum url="https://repo1.maven.org/maven2/commons-logging/commons-logging/${commons-logging-version}/commons-logging-${commons-logging-version}-api.jar"/>
     <get-and-checksum url="https://repo1.maven.org/maven2/org/apache/commons/commons-text/${commons-text-version}/commons-text-${commons-text-version}.jar"/>
     <get-and-checksum url="https://repo1.maven.org/maven2/javax/mail/mail/${mail-version}/mail-${mail-version}.jar"/>
-    <get-and-checksum url="https://repo1.maven.org/maven2/org/eclipse/jetty/toolchain/jetty-jakarta-servlet-api/${jakarta.servlet-api-version}/jetty-jakarta-servlet-api-${jakarta.servlet-api-version}.jar"/>
+    <get-and-checksum url="https://repo1.maven.org/maven2/jakarta/servlet/jakarta.servlet-api/${jakarta.servlet-api-version}/jakarta.servlet-api-${jakarta.servlet-api-version}.jar"/>
     <get-and-checksum url="https://repo1.maven.org/maven2/log4j/log4j/${log4j-version}/log4j-${log4j-version}.jar"/>
     <get-and-checksum url="https://repo1.maven.org/maven2/net/sourceforge/jchardet/jchardet/${jchardet-version}/jchardet-${jchardet-version}.jar" checksum.pattern="{0} "/>
     <get-and-checksum url="https://repo1.maven.org/maven2/org/glassfish/javax.json/${javax.json-version}/javax.json-${javax.json-version}.jar"/>
@@ -269,7 +270,7 @@ DEALINGS IN THE SOFTWARE.
       <zipfileset src="${depsDir}/jetty-io-${jetty-version}.jar" unless:true="${jar-without-deps}">
         <exclude name="module-info.class" />
       </zipfileset>
-      <zipfileset src="${depsDir}/jetty-jakarta-servlet-api-${jakarta.servlet-api-version}.jar" unless:true="${jar-without-deps}">
+      <zipfileset src="${depsDir}/jakarta.servlet-api-${jakarta.servlet-api-version}.jar" unless:true="${jar-without-deps}">
         <exclude name="module-info.class" />
       </zipfileset>
       <zipfileset src="${depsDir}/jetty-security-${jetty-version}.jar" unless:true="${jar-without-deps}">
@@ -278,10 +279,13 @@ DEALINGS IN THE SOFTWARE.
       <zipfileset src="${depsDir}/jetty-server-${jetty-version}.jar" unless:true="${jar-without-deps}">
         <exclude name="module-info.class" />
       </zipfileset>
-      <zipfileset src="${depsDir}/jetty-servlet-${jetty-version}.jar" unless:true="${jar-without-deps}">
+      <zipfileset src="${depsDir}/jetty-ee10-servlet-${jetty-version}.jar" unless:true="${jar-without-deps}">
         <exclude name="module-info.class" />
       </zipfileset>
-      <zipfileset src="${depsDir}/jetty-servlets-${jetty-version}.jar" unless:true="${jar-without-deps}">
+      <zipfileset src="${depsDir}/jetty-ee10-servlets-${jetty-version}.jar" unless:true="${jar-without-deps}">
+        <exclude name="module-info.class" />
+      </zipfileset>
+      <zipfileset src="${depsDir}/jetty-session-${jetty-version}.jar" unless:true="${jar-without-deps}">
         <exclude name="module-info.class" />
       </zipfileset>
       <zipfileset src="${depsDir}/jetty-util-${jetty-version}.jar" unless:true="${jar-without-deps}">
@@ -345,7 +349,7 @@ DEALINGS IN THE SOFTWARE.
       <lib file="${depsDir}/log4j-${log4j-version}.jar"/>
       <lib file="${depsDir}/slf4j-api-${slf4j-api-version}.jar"/>
       <lib file="${depsDir}/javax.json-${javax.json-version}.jar"/>
-      <lib file="${depsDir}/jetty-jakarta-servlet-api-${jakarta.servlet-api-version}.jar"/>
+      <lib file="${depsDir}/jakarta.servlet-api-${jakarta.servlet-api-version}.jar"/>
       <classes dir="${validator.build.basedir}/core/classes"/>
       <classes dir="${validator.build.basedir}/resources"/>
       <classes file="${validator.basedir}/resources/war/log4j.xml"/>
@@ -366,9 +370,10 @@ DEALINGS IN THE SOFTWARE.
     <fileset dir="${depsDir}/" includes="icu4j-${icu4j-version}.jar" />
     <fileset dir="${depsDir}/" includes="javax.json-${javax.json-version}.jar" />
     <fileset dir="${depsDir}/" includes="jetty-client-${jetty-version}.jar" />
-    <fileset dir="${depsDir}/" includes="jetty-jakarta-servlet-api-${jakarta.servlet-api-version}.jar" />
+    <fileset dir="${depsDir}/" includes="jakarta.servlet-api-${jakarta.servlet-api-version}.jar" />
     <fileset dir="${depsDir}/" includes="jetty-server-${jetty-version}.jar" />
-    <fileset dir="${depsDir}/" includes="jetty-servlet-${jetty-version}.jar" />
+    <fileset dir="${depsDir}/" includes="jetty-ee10-servlet-${jetty-version}.jar" />
+    <fileset dir="${depsDir}/" includes="jetty-session-${jetty-version}.jar" />
     <fileset dir="${depsDir}/" includes="jetty-util-${jetty-version}.jar" />
     <fileset dir="${depsDir}/" includes="jetty-http-${jetty-version}.jar" />
     <fileset dir="${depsDir}/" includes="jetty-io-${jetty-version}.jar" />
@@ -482,7 +487,7 @@ DEALINGS IN THE SOFTWARE.
     <fileset dir="${depsDir}/" includes="jetty-http-${jetty-version}.jar" />
     <fileset dir="${depsDir}/" includes="jetty-io-${jetty-version}.jar" />
     <fileset dir="${depsDir}/" includes="jetty-util-${jetty-version}.jar" />
-    <fileset dir="${depsDir}/" includes="jetty-jakarta-servlet-api-${jakarta.servlet-api-version}.jar" />
+    <fileset dir="${depsDir}/" includes="jakarta.servlet-api-${jakarta.servlet-api-version}.jar" />
     <fileset dir="${depsDir}/" includes="log4j-${log4j-version}.jar" />
     <fileset dir="${depsDir}/" includes="htmlunit-csp-${htmlunit-csp-version}.jar" />
     <pathelement location="css-validator/css-validator.jar"/>
@@ -531,9 +536,9 @@ DEALINGS IN THE SOFTWARE.
 
 
   <path id="validator-split-server.classpath">
-    <fileset dir="${depsDir}/" includes="jetty-jakarta-servlet-api-${jakarta.servlet-api-version}.jar" />
+    <fileset dir="${depsDir}/" includes="jakarta.servlet-api-${jakarta.servlet-api-version}.jar" />
     <fileset dir="${depsDir}/" includes="jetty-server-${jetty-version}.jar" />
-    <fileset dir="${depsDir}/" includes="jetty-servlet-${jetty-version}.jar" />
+    <fileset dir="${depsDir}/" includes="jetty-ee10-servlet-${jetty-version}.jar" />
     <fileset dir="${depsDir}/" includes="jetty-util-${jetty-version}.jar" />
     <fileset dir="${depsDir}/" includes="log4j-${log4j-version}.jar" />
     <pathelement path="${validator.build.basedir}/core/classes/"/>
@@ -545,6 +550,7 @@ DEALINGS IN THE SOFTWARE.
     <pathelement location="${depsDir}/jetty-http-${jetty-version}.jar" />
     <pathelement location="${depsDir}/jetty-io-${jetty-version}.jar" />
     <pathelement location="${depsDir}/jetty-security-${jetty-version}.jar" />
+    <pathelement location="${depsDir}/jetty-session-${jetty-version}.jar" />
     <pathelement location="${depsDir}/slf4j-api-${slf4j-api-version}.jar"/>
     <pathelement location="${depsDir}/slf4j-log4j12-${slf4j-log4j12-version}.jar"/>
   </path>
@@ -779,7 +785,8 @@ DEALINGS IN THE SOFTWARE.
       <dependency groupId="org.eclipse.jetty" artifactId="jetty-io" version="${jetty-version}"/>
       <dependency groupId="org.eclipse.jetty" artifactId="jetty-security" version="${jetty-version}"/>
       <dependency groupId="org.eclipse.jetty" artifactId="jetty-server" version="${jetty-version}"/>
-      <dependency groupId="org.eclipse.jetty" artifactId="jetty-servlets" version="${jetty-version}"/>
+      <dependency groupId="org.eclipse.jetty" artifactId="jetty-ee10-servlets" version="${jetty-version}"/>
+      <dependency groupId="org.eclipse.jetty" artifactId="jetty-session" version="${jetty-version}"/>
       <dependency groupId="org.eclipse.jetty" artifactId="jetty-util" version="${jetty-version}"/>
       <dependency groupId="org.glassfish" artifactId="javax.json" version="${javax.json-version}"/>
     </artifact:pom>

--- a/src/nu/validator/servlet/Main.java
+++ b/src/nu/validator/servlet/Main.java
@@ -51,9 +51,9 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.FilterHolder;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.FilterHolder;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 /**

--- a/src/nu/validator/xml/PrudentHttpEntityResolver.java
+++ b/src/nu/validator/xml/PrudentHttpEntityResolver.java
@@ -46,9 +46,9 @@ import nu.validator.io.SystemIdIOException;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpClientTransport;
-import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.client.util.InputStreamResponseListener;
+import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.InputStreamResponseListener;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -350,7 +350,7 @@ public class PrudentHttpEntityResolver
             }
             InputStreamResponseListener listener = new InputStreamResponseListener();
             jettyRequest.send(listener);
-            org.eclipse.jetty.client.api.Response response = listener.get(
+            org.eclipse.jetty.client.Response response = listener.get(
                     socketTimeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS);
             boolean ignoreResponseStatus = false;
             if (request != null && request.getAttribute(


### PR DESCRIPTION
jetty 11 is not supported anymore upstream

Jetty 12 requires Java/JVM 17 as per https://jetty.org/download.html. So the CI job running with java 11 would fail.

